### PR TITLE
ci: pin golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,3 +39,5 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        with:
+          version: v2.11.4


### PR DESCRIPTION
## Summary

Pin `golangci/golangci-lint-action@v9` to **golangci-lint v2.11.4**.

## Why

The Lint workflow had no `version:` input, so it resolved to `latest`. Upstream shipped **v2.12.1** which strengthened the `goconst` rule and now flags **50 pre-existing literals in `internal/logging/`**.

Effect: every PR that touches any `.go` file fails Lint, even when the PR does not modify `internal/logging/`. PR #14 (StatefulSet support) is the current victim — its diff is clean, but it cannot land while CI is red on unrelated code.

Last green Lint on `main` (2026-04-19, commit \`91fa416\`) used **v2.11.4**, so pinning there restores the exact known-good state with no behavior change for code that was already passing.

## Follow-ups (not in this PR)

1. Backlog: clean up the `goconst` hits in `internal/logging/` (extract repeated literals like `controller`, `duration`, `PodDisruptionBudget`, `default`, `info`, `key1`, `key2`, etc. into package-level constants).
2. After (1), bump the pin deliberately to v2.12.x or later.


## Verification

After merge, re-run the Lint job on PR #14  it should go green, leaving only the genuine review items (\`KindLower()\` casing + enforcement-mode unit tests) for the contributor to address.