### PR TITLE
chore: reduce log noise and add maintenance annotation constants

### DIFF
--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -59,6 +59,8 @@ const (
 	// ODA Canvas annotation keys
 	AnnotationAvailabilityClass = "pdboperator.io/availability-class"
 	AnnotationMaintenanceWindow = "pdboperator.io/maintenance-window"
+	AnnotationMaintenanceMode   = "pdboperator.io/maintenance-mode"
+	AnnotationMaintenanceStart  = "pdboperator.io/maintenance-start"
 	AnnotationWorkloadFunction  = "pdboperator.io/workload-function"
 	AnnotationWorkloadName      = "pdboperator.io/workload-name"
 	AnnotationOverrideReason    = "pdboperator.io/override-reason"
@@ -1388,9 +1390,9 @@ func (r *DeploymentReconciler) updatePDB(ctx context.Context, pdb *policyv1.PodD
 	}
 
 	// Check if we're exiting maintenance mode
-	if pdb.Annotations["pdboperator.io/maintenance-mode"] == "true" {
-		delete(pdb.Annotations, "pdboperator.io/maintenance-mode")
-		delete(pdb.Annotations, "pdboperator.io/maintenance-start")
+	if pdb.Annotations[AnnotationMaintenanceMode] == maintenanceModeActive {
+		delete(pdb.Annotations, AnnotationMaintenanceMode)
+		delete(pdb.Annotations, AnnotationMaintenanceStart)
 		needsUpdate = true
 	}
 
@@ -1564,8 +1566,8 @@ func (r *DeploymentReconciler) removePDBTemporarily(ctx context.Context, deploym
 	if pdb.Annotations == nil {
 		pdb.Annotations = make(map[string]string)
 	}
-	pdb.Annotations["pdboperator.io/maintenance-mode"] = "true"
-	pdb.Annotations["pdboperator.io/maintenance-start"] = time.Now().Format(time.RFC3339)
+	pdb.Annotations[AnnotationMaintenanceMode] = maintenanceModeActive
+	pdb.Annotations[AnnotationMaintenanceStart] = time.Now().Format(time.RFC3339)
 
 	// Temporarily disable PDB by setting minAvailable to 0
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: 0}

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -184,22 +184,20 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	stateChanged := r.tracker.HasStateChanged(ctx, r.Client, w, config)
 
-	logger.Info("Change detection result", map[string]any{
-		"stateChanged": stateChanged,
-		"statefulset":  sts.Name,
-		"namespace":    sts.Namespace,
-		"generation":   sts.Generation,
-		"debug":        true,
-	})
+	logger.V(1).Info("Change detection result",
+		"stateChanged", stateChanged,
+		"statefulset", sts.Name,
+		"namespace", sts.Namespace,
+		"generation", sts.Generation,
+	)
 
 	pdbName := types.NamespacedName{Name: sts.Name + DefaultPDBSuffix, Namespace: sts.Namespace}
 	currentPDB := &policyv1.PodDisruptionBudget{}
 	pdbExists := r.Get(ctx, pdbName, currentPDB) == nil
-	logger.Info("PDB existence check", map[string]any{
-		"pdbName":   pdbName.Name,
-		"pdbExists": pdbExists,
-		"debug":     true,
-	})
+	logger.V(1).Info("PDB existence check",
+		"pdbName", pdbName.Name,
+		"pdbExists", pdbExists,
+	)
 
 	if !stateChanged {
 		logger.Info("Skipping reconciliation - no state change detected", map[string]any{

--- a/internal/controller/workload.go
+++ b/internal/controller/workload.go
@@ -655,8 +655,8 @@ func RemovePDBTemporarily(ctx context.Context, c client.Client, w WorkloadAccess
 	if pdb.Annotations == nil {
 		pdb.Annotations = make(map[string]string)
 	}
-	pdb.Annotations["pdboperator.io/maintenance-mode"] = maintenanceModeActive
-	pdb.Annotations["pdboperator.io/maintenance-start"] = time.Now().Format(time.RFC3339)
+	pdb.Annotations[AnnotationMaintenanceMode] = maintenanceModeActive
+	pdb.Annotations[AnnotationMaintenanceStart] = time.Now().Format(time.RFC3339)
 	pdb.Spec.MinAvailable = &intstr.IntOrString{Type: intstr.Int, IntVal: 0}
 	if err := c.Patch(ctx, pdb, patch); err != nil {
 		return err
@@ -771,9 +771,9 @@ func UpdatePDB(ctx context.Context, c client.Client, eventsRecorder *events.Even
 		pdb.Annotations[AnnotationEnforcement] = config.Enforcement
 		needsUpdate = true
 	}
-	if pdb.Annotations["pdboperator.io/maintenance-mode"] == maintenanceModeActive {
-		delete(pdb.Annotations, "pdboperator.io/maintenance-mode")
-		delete(pdb.Annotations, "pdboperator.io/maintenance-start")
+	if pdb.Annotations[AnnotationMaintenanceMode] == maintenanceModeActive {
+		delete(pdb.Annotations, AnnotationMaintenanceMode)
+		delete(pdb.Annotations, AnnotationMaintenanceStart)
 		needsUpdate = true
 	}
 	if !selectorEquals(pdb.Spec.Selector, w.GetSelector()) {


### PR DESCRIPTION
Addresses two of the three backlog items from #30 (the quick, low-risk ones). The larger `deploymentWorkload` adapter refactor (item 1) is left for a separate focused PR.

## Changes

### Reduce log noise (item 2)
`statefulset_controller.go`: the `Change detection result` and `PDB existence check` diagnostics moved from `logger.Info(...)` to `logger.V(1).Info(...)`, and the `"debug": true` marker dropped. `V(1)` routes through the base logger so these are gated by verbosity and stay out of production logs at default level. (The `Debug` method on the unified logger is not verbosity-gated, so `V(1)` is the correct lever here.)

### Maintenance annotation constants (item 3)
Added `AnnotationMaintenanceMode` and `AnnotationMaintenanceStart` next to the other annotation keys, and replaced the inline `pdboperator.io/maintenance-mode` / `pdboperator.io/maintenance-start` string literals in `workload.go` and `deployment_controller.go`.

## Verification
- `make build`, `make test`, `make lint` all green.
- Pure refactor / log-level change; no behavior change, no new tests needed.

## Note
`deployment_controller.go` also carries a few `"debug": true` `logger.Info` entries (lines ~306, 320, 422, 1829, 1842). #30 scoped item 2 to the StatefulSet controller, so I left those untouched to keep this PR surgical. Happy to fold them in here or as a follow-up if you'd prefer the deployment controller cleaned up too.

Refs #30.