### PR TITLE
ci: pin golangci-lint to v2.11.4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
+        with:
+          version: v2.11.4
 
   test:
     name: Unit Tests


### PR DESCRIPTION
The `v0.2.0` release run failed at the **Lint** job, which blocked the release (it `needs: [lint, test, test-e2e]`), so no image or GitHub Release was produced.

## Cause
`release.yml`'s lint job used `golangci/golangci-lint-action` without a `version`, so it installed `latest` (v2.12.2). That newer linter flags pre-existing `goconst` findings in `internal/logging/*` test files. The PR workflow `lint.yml` already pins `version: v2.11.4`, so this was an inconsistency between the two workflows, not a code regression (`make lint` is green locally).

## Fix
Pin the release lint job to `version: v2.11.4`, matching `lint.yml`.

After merge, the `v0.2.0` tag (currently dangling, no artifacts) will be re-cut so the release runs with the pinned linter.