### PR TITLE
fix: clean up Deployment PDB on scale-down below 2 replicas

### DIFF
--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -245,6 +245,13 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			attribute.Int("replicas", int(replicas)),
 		)
 
+		// clean up a PDB left over from a previous multi-replica state, else it orphans and blocks evictions
+		if err := CleanupPDB(ctx, r.Client, r.Events, &deploymentWorkload{deployment}, logger.ToLogr()); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to clean up PDB for single-replica Deployment", map[string]any{})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+		}
+
 		// Record event
 		if r.Events != nil {
 			r.Events.DeploymentSkipped(deployment, deployment.Name, "insufficient replicas")

--- a/internal/controller/deployment_controller_test.go
+++ b/internal/controller/deployment_controller_test.go
@@ -2294,6 +2294,79 @@ func TestDeploymentReconciler_AvailabilityClassPDBValues(t *testing.T) {
 	}
 }
 
+func TestDeploymentReconciler_ScaleDownCleansUpPDB(t *testing.T) {
+	ctx := context.Background()
+
+	// Deployment scaled down to 1 replica, still carrying a PDB from its multi-replica state
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scaledown-deployment",
+			Namespace: "default",
+			UID:       types.UID("scaledown-deploy-uid"),
+			Annotations: map[string]string{
+				AnnotationAvailabilityClass: "high-availability",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "scaledown-deployment"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "scaledown-deployment"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "nginx"}},
+				},
+			},
+		},
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scaledown-deployment-pdb",
+			Namespace: "default",
+			Labels:    map[string]string{LabelManagedBy: OperatorName},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "apps/v1",
+					Kind:               "Deployment",
+					Name:               "scaledown-deployment",
+					UID:                deployment.UID,
+					Controller:         &[]bool{true}[0],
+					BlockOwnerDeletion: &[]bool{true}[0],
+				},
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &intstr.IntOrString{Type: intstr.String, StrVal: "75%"},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "scaledown-deployment"},
+			},
+		},
+	}
+
+	tr := CreateTestReconcilers(deployment, pdb)
+	reconciler := tr.DeploymentReconciler
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "scaledown-deployment", Namespace: "default"},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	// the orphaned PDB from the prior multi-replica state must be removed
+	deletedPDB := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, types.NamespacedName{
+		Name:      "scaledown-deployment-pdb",
+		Namespace: "default",
+	}, deletedPDB)
+	assert.True(t, errors.IsNotFound(err), "PDB should be cleaned up when Deployment scales below 2 replicas")
+}
+
 // Helper functions
 
 func int32Ptr(i int32) *int32 {


### PR DESCRIPTION
## Problem
The Deployment reconcile path early-returns at the `replicas < 2` check (`deployment_controller.go:237`) and fires `DeploymentSkipped`, but never deletes an existing PDB. Scaling a Deployment from 3 to 1 leaves a stale PDB (e.g. `minAvailable: 75%`) on the single surviving pod, which then **blocks evictions, node drains, rolling node upgrades, and cluster-autoscaler**.

This is the same bug class fixed for StatefulSets in the Round 4 review (Blocker 1). The StatefulSet path calls `CleanupPDB` before its early return; the Deployment path was never given the same treatment. It predates the v0.2.0 work.

## Fix
Call the shared `CleanupPDB` (via the `deploymentWorkload` adapter) before the early return, mirroring the StatefulSet controller. On cleanup error it requeues rather than swallowing.

## Test
`TestDeploymentReconciler_ScaleDownCleansUpPDB`: a 1-replica Deployment with a pre-existing owned PDB reconciles and asserts the PDB is deleted. Mirrors `TestStatefulSetReconciler_ScaleDownCleansUpPDB`.

## Verification
- `make build`, `make test`, `make lint` all green.