### PR TITLE
test: de-flake time-dependent maintenance-window tests

### DIFF
--- a/internal/controller/controller_helpers_test.go
+++ b/internal/controller/controller_helpers_test.go
@@ -1186,6 +1186,9 @@ func TestIsInMaintenanceWindow(t *testing.T) {
 	now := time.Now().UTC()
 	startTime := now.Add(-1 * time.Hour).Format("15:04")
 	endTime := now.Add(1 * time.Hour).Format("15:04")
+	// a window 2-3h ahead is never active regardless of when the test runs
+	outsideStart := now.Add(2 * time.Hour).Format("15:04")
+	outsideEnd := now.Add(3 * time.Hour).Format("15:04")
 
 	tests := []struct {
 		name     string
@@ -1202,7 +1205,7 @@ func TestIsInMaintenanceWindow(t *testing.T) {
 		{
 			name: "outside maintenance window",
 			config: &AvailabilityConfig{
-				MaintenanceWindow: "03:00-04:00 UTC",
+				MaintenanceWindow: outsideStart + "-" + outsideEnd + " UTC",
 			},
 			expected: false,
 		},

--- a/internal/controller/deployment_controller_test.go
+++ b/internal/controller/deployment_controller_test.go
@@ -355,6 +355,10 @@ func TestDeploymentReconciler_SingleReplicaDeployment(t *testing.T) {
 func TestDeploymentReconciler_MaintenanceWindow(t *testing.T) {
 	ctx := context.Background()
 
+	// a window 2-3h ahead is never active regardless of when the test runs
+	now := time.Now().UTC()
+	inactiveWindow := now.Add(2*time.Hour).Format("15:04") + "-" + now.Add(3*time.Hour).Format("15:04") + " UTC"
+
 	// Create deployment with maintenance window annotation
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -362,7 +366,7 @@ func TestDeploymentReconciler_MaintenanceWindow(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				AnnotationAvailabilityClass: "standard",
-				AnnotationMaintenanceWindow: "02:00-04:00 UTC", // Not active now
+				AnnotationMaintenanceWindow: inactiveWindow,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/internal/controller/statefulset_controller_test.go
+++ b/internal/controller/statefulset_controller_test.go
@@ -435,9 +435,13 @@ func TestStatefulSetReconciler_UpdatePDB(t *testing.T) {
 func TestStatefulSetReconciler_MaintenanceWindow(t *testing.T) {
 	ctx := context.Background()
 
+	// a window 2-3h ahead is never active regardless of when the test runs
+	now := time.Now().UTC()
+	inactiveWindow := now.Add(2*time.Hour).Format("15:04") + "-" + now.Add(3*time.Hour).Format("15:04") + " UTC"
+
 	sts := newTestStatefulSet("maintenance-sts", "default", 3, map[string]string{
 		AnnotationAvailabilityClass: "standard",
-		AnnotationMaintenanceWindow: "02:00-04:00 UTC", // Not active now
+		AnnotationMaintenanceWindow: inactiveWindow,
 	}, nil)
 
 	tr := CreateTestReconcilers(sts)


### PR DESCRIPTION
Closes #37.

## Problem
`TestIsInMaintenanceWindow/outside_maintenance_window`, `TestDeploymentReconciler_MaintenanceWindow`, and `TestStatefulSetReconciler_MaintenanceWindow` hardcoded a `02:00-04:00` / `03:00-04:00 UTC` window assumed inactive. When CI ran in that UTC range the window activated, the operator relaxed/removed the PDB, and the assertions failed (seen in run 27892681325 at 03:52 UTC).

## Fix
Compute the inactive window relative to `time.Now()` (a 1-hour window 2-3 hours ahead, which can never contain `now`). This mirrors how `TestIsInMaintenanceWindow`'s "within" case already derives its window from `now`. No hardcoded absolute clock times remain for active/inactive assertions.

## Verification
- `make test` and `make lint` green.
- The 2-3h-ahead window is provably outside `now` for any time of day (including the midnight-wrap cases handled by `IsInMaintenanceWindow`), so the tests are now time-independent.