### PR TITLE
fix: grant deployments/statefulsets finalizers RBAC for blockOwnerDeletion

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - statefulsets/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - availability.pdboperator.io
   resources:
   - pdbpolicies

--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -123,6 +123,7 @@ type AvailabilityConfig struct {
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=get;patch;update
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=availability.pdboperator.io,resources=pdbpolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -62,6 +62,7 @@ type StatefulSetReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=get;patch;update
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=availability.pdboperator.io,resources=pdbpolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch


### PR DESCRIPTION
Part of #40 (operator-repo side).

## Problem
The operator sets `blockOwnerDeletion: true` on PDB owner references (via `ctrl.SetControllerReference` in `internal/controller/workload.go`). On clusters with `OwnerReferencesPermissionEnforcement` enabled (e.g. OpenShift), creating such an object requires `update` on the owner's `/finalizers` subresource, or PDB creation fails:

```
poddisruptionbudgets.policy is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```

The operator repo's own RBAC (`config/rbac/role.yaml`) granted no `/finalizers` on `deployments` or `statefulsets`, so `make deploy`/`make install` is broken on OpenShift. (helm-pdb-operator #6 already fixed `deployments/finalizers` in the chart; the chart-side `statefulsets/finalizers` + test is a separate PR.)

## Fix
Add kubebuilder RBAC markers and regenerate the manifest:
- `deployment_controller.go`: `apps/deployments/finalizers` `get;patch;update`
- `statefulset_controller.go`: `apps/statefulsets/finalizers` `get;patch;update`
- regenerated `config/rbac/role.yaml`

This is the [Operator SDK FAQ](https://sdk.operatorframework.io/docs/faqs/)-recommended fix and matches how the Apache Flink and OpenShift operators handle the same case.

## Verification
- `make manifests` regenerated `role.yaml` with both finalizers rules (`get;patch;update`).
- `make build`, `make test`, `make lint` green.

RBAC-only change; no controller logic touched.