### PR TITLE
docs: add CHANGELOG section for v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-21
+
+### Fixed
+- Grant `apps/deployments/finalizers` and `apps/statefulsets/finalizers` RBAC, required to set `blockOwnerDeletion` on PDB owner references on clusters that enforce ownerReference rules (e.g. OpenShift / `OwnerReferencesPermissionEnforcement`). Without it, PDB creation failed with "cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on" (#41)
+
 ## [0.2.1] - 2026-06-21
 
 ### Fixed
@@ -73,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Distroless container base image (`gcr.io/distroless/static:nonroot`)
 - Comprehensive test suite with 71-93% coverage across packages
 
-[Unreleased]: https://github.com/pdb-operator/pdb-operator/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/pdb-operator/pdb-operator/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/pdb-operator/pdb-operator/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/pdb-operator/pdb-operator/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/pdb-operator/pdb-operator/compare/v0.1.1...v0.2.0
 [0.1.0]: https://github.com/pdb-operator/pdb-operator/releases/tag/v0.1.0


### PR DESCRIPTION
Release notes for v0.2.2 (the finalizers RBAC fix, #41). The release workflow extracts notes from the `## [0.2.2]` section on tag push.