### PR TITLE
Evaluate PDBPolicy maintenance windows (+ clock injection, state-tracker errors, cleanups)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -94,7 +95,6 @@ require (
 	k8s.io/component-base v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/client/circuit_breaker.go
+++ b/internal/client/circuit_breaker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -708,14 +709,5 @@ func (w *adaptiveStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfi
 // Helper functions
 
 func sortDurations(durations []time.Duration) {
-	// Simple insertion sort for small arrays
-	for i := 1; i < len(durations); i++ {
-		key := durations[i]
-		j := i - 1
-		for j >= 0 && durations[j] > key {
-			durations[j+1] = durations[j]
-			j--
-		}
-		durations[j+1] = key
-	}
+	slices.Sort(durations)
 }

--- a/internal/controller/controller_helpers_test.go
+++ b/internal/controller/controller_helpers_test.go
@@ -467,17 +467,20 @@ func TestCalculateDeploymentFingerprint(t *testing.T) {
 		lastDeploymentState: make(map[types.NamespacedName]string),
 		mu:                  sync.RWMutex{},
 	}
-	fingerprint := reconciler.calculateDeploymentFingerprint(ctx, deployment, config)
+	fingerprint, err := reconciler.calculateDeploymentFingerprint(ctx, deployment, config)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, fingerprint, "Fingerprint should not be empty")
 
 	// Same deployment should produce same fingerprint
-	fingerprint2 := reconciler.calculateDeploymentFingerprint(ctx, deployment, config)
+	fingerprint2, err := reconciler.calculateDeploymentFingerprint(ctx, deployment, config)
+	assert.NoError(t, err)
 	assert.Equal(t, fingerprint, fingerprint2, "Same deployment should produce same fingerprint")
 
 	// Different deployment should produce different fingerprint
 	deployment2 := deployment.DeepCopy()
 	deployment2.Spec.Replicas = func() *int32 { i := int32(5); return &i }()
-	fingerprint3 := reconciler.calculateDeploymentFingerprint(ctx, deployment2, config)
+	fingerprint3, err := reconciler.calculateDeploymentFingerprint(ctx, deployment2, config)
+	assert.NoError(t, err)
 	assert.NotEqual(t, fingerprint, fingerprint3, "Different deployment should produce different fingerprint")
 }
 

--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sevents "k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,10 +104,19 @@ type DeploymentReconciler struct {
 	Events      *events.EventRecorder
 	PolicyCache *cache.PolicyCache
 	Config      *SharedConfig
+	// Clock is injectable for deterministic maintenance-window tests; defaults to real time.
+	Clock clock.PassiveClock
 
 	// Change detection to avoid unnecessary reconciliations
 	lastDeploymentState map[types.NamespacedName]string
 	mu                  sync.RWMutex
+}
+
+func (r *DeploymentReconciler) now() time.Time {
+	if r.Clock != nil {
+		return r.Clock.Now()
+	}
+	return time.Now()
 }
 
 // AvailabilityConfig holds the configuration for a deployment's availability requirements
@@ -116,9 +126,11 @@ type AvailabilityConfig struct {
 	MinAvailable      intstr.IntOrString
 	Description       string
 	MaintenanceWindow string
-	Source            string // "annotation", "policy", etc.
-	PolicyName        string // Name of the policy if from policy
-	Enforcement       string // Enforcement mode if from policy
+	// MaintenanceWindows carries structured windows from the matched PDBPolicy.
+	MaintenanceWindows []availabilityv1alpha1.MaintenanceWindow
+	Source             string // "annotation", "policy", etc.
+	PolicyName         string // Name of the policy if from policy
+	Enforcement        string // Enforcement mode if from policy
 }
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
@@ -444,7 +456,8 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		"reconcileID":       reconcileID,
 	})
 
-	return result, nil
+	// wake up proactively when a maintenance window is due to open
+	return applyMaintenanceRequeue(result, config, r.now()), nil
 }
 
 // getAvailabilityConfigWithCache gets configuration with the new priority logic
@@ -475,6 +488,11 @@ func (r *DeploymentReconciler) getAvailabilityConfigWithCache(ctx context.Contex
 	if finalConfig == nil {
 		logger.V(1).Info("No availability configuration found")
 		return nil, nil
+	}
+
+	// carry policy maintenance windows onto whichever config wins resolution
+	if matchedPolicy != nil {
+		finalConfig.MaintenanceWindows = matchedPolicy.Spec.MaintenanceWindows
 	}
 
 	return finalConfig, nil
@@ -1079,83 +1097,9 @@ func (r *DeploymentReconciler) cleanupDuplicatePDBs(ctx context.Context, deploym
 
 // Helper functions
 
-// isInMaintenanceWindow checks if currently in a maintenance window
-func (r *DeploymentReconciler) isInMaintenanceWindow(config *AvailabilityConfig, logger logr.Logger) bool {
-	if config.MaintenanceWindow == "" {
-		return false
-	}
-
-	// Cache key for maintenance window
-	cacheKey := fmt.Sprintf("maintenance-window-%s", config.MaintenanceWindow)
-
-	// Check cache first if available
-	if r.PolicyCache != nil {
-		if cachedResult, found := r.PolicyCache.GetMaintenanceWindow(cacheKey); found {
-			return cachedResult
-		}
-	}
-
-	// Parse maintenance window (format: "02:00-04:00 UTC")
-	parts := strings.Fields(config.MaintenanceWindow)
-	if len(parts) < 1 {
-		logger.Error(fmt.Errorf("invalid maintenance window format"),
-			"Expected format: 'HH:MM-HH:MM UTC'",
-			"got", config.MaintenanceWindow)
-		return false
-	}
-
-	timeRange := parts[0]
-	timezone := "UTC"
-	if len(parts) > 1 {
-		timezone = parts[1]
-	}
-
-	// Parse time range
-	timeParts := strings.Split(timeRange, "-")
-	if len(timeParts) != 2 {
-		logger.Error(fmt.Errorf("invalid time range format"),
-			"Expected format: 'HH:MM-HH:MM'",
-			"got", timeRange)
-		return false
-	}
-
-	location, err := time.LoadLocation(timezone)
-	if err != nil {
-		logger.Error(err, "Invalid timezone", "timezone", timezone)
-		return false
-	}
-
-	now := time.Now().In(location)
-
-	// Convert to today's time in the specified timezone
-	today := now.Format("2006-01-02")
-	todayStart, err := time.ParseInLocation("2006-01-02 15:04", fmt.Sprintf("%s %s", today, timeParts[0]), location)
-	if err != nil {
-		logger.Error(err, "Invalid start time format", "startTime", timeParts[0])
-		return false
-	}
-
-	todayEnd, err := time.ParseInLocation("2006-01-02 15:04", fmt.Sprintf("%s %s", today, timeParts[1]), location)
-	if err != nil {
-		logger.Error(err, "Invalid end time format", "endTime", timeParts[1])
-		return false
-	}
-
-	// Handle overnight maintenance windows
-	var result bool
-	if todayEnd.Before(todayStart) {
-		// Maintenance window spans midnight
-		result = now.After(todayStart) || now.Before(todayEnd)
-	} else {
-		result = now.After(todayStart) && now.Before(todayEnd)
-	}
-
-	// Cache the result for 1 minute if cache is available
-	if r.PolicyCache != nil {
-		r.PolicyCache.SetMaintenanceWindow(cacheKey, result, 1*time.Minute)
-	}
-
-	return result
+// isInMaintenanceWindow checks if currently in a maintenance window (annotation or policy).
+func (r *DeploymentReconciler) isInMaintenanceWindow(config *AvailabilityConfig, _ logr.Logger) bool {
+	return IsInMaintenanceWindow(config, r.now())
 }
 
 // removePDBTemporarily disables PDB during maintenance window
@@ -1325,7 +1269,7 @@ func (r *DeploymentReconciler) calculateDeploymentFingerprint(
 	ctx context.Context,
 	deployment *appsv1.Deployment,
 	config *AvailabilityConfig,
-) string {
+) (string, error) {
 	h := sha256.New()
 
 	// Include deployment generation (changes on spec updates)
@@ -1384,7 +1328,9 @@ func (r *DeploymentReconciler) calculateDeploymentFingerprint(
 	}
 
 	currentPDB := &policyv1.PodDisruptionBudget{}
-	if err := r.Get(ctx, pdbName, currentPDB); err == nil {
+	err := r.Get(ctx, pdbName, currentPDB)
+	switch {
+	case err == nil:
 		// PDB exists - include its current spec
 		_, _ = h.Write([]byte("pdb:exists=true"))
 		_, _ = fmt.Fprintf(h, "pdb:minAvailable=%s", currentPDB.Spec.MinAvailable.String())
@@ -1393,9 +1339,12 @@ func (r *DeploymentReconciler) calculateDeploymentFingerprint(
 				_, _ = fmt.Fprintf(h, "pdb:selector:%s=%s", key, value)
 			}
 		}
-	} else {
+	case errors.IsNotFound(err):
 		// PDB doesn't exist - include marker so fingerprint changes when PDB is deleted
 		_, _ = h.Write([]byte("pdb:exists=false"))
+	default:
+		// transient API/cache error - propagate so the reconciler requeues instead of acting on a wrong fingerprint
+		return "", err
 	}
 
 	// Also include expected PDB state based on configuration
@@ -1409,7 +1358,7 @@ func (r *DeploymentReconciler) calculateDeploymentFingerprint(
 		}
 	}
 
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // hasDeploymentStateChanged checks if the deployment state has changed
@@ -1431,7 +1380,10 @@ func (r *DeploymentReconciler) hasDeploymentStateChanged(
 		Namespace: deployment.Namespace,
 	}
 
-	currentFingerprint := r.calculateDeploymentFingerprint(ctx, deployment, config)
+	currentFingerprint, err := r.calculateDeploymentFingerprint(ctx, deployment, config)
+	if err != nil {
+		return false, err
+	}
 
 	lastFingerprint, exists := r.lastDeploymentState[key]
 	if !exists {
@@ -1476,7 +1428,10 @@ func (r *DeploymentReconciler) updateDeploymentState(
 		Namespace: deployment.Namespace,
 	}
 
-	fingerprint := r.calculateDeploymentFingerprint(ctx, deployment, config)
+	fingerprint, err := r.calculateDeploymentFingerprint(ctx, deployment, config)
+	if err != nil {
+		return err
+	}
 
 	r.lastDeploymentState[key] = fingerprint
 	return nil

--- a/internal/controller/deployment_controller_test.go
+++ b/internal/controller/deployment_controller_test.go
@@ -408,8 +408,8 @@ func TestDeploymentReconciler_MaintenanceWindow(t *testing.T) {
 	// Outside maintenance window, should create PDB normally
 	result, err = reconciler.Reconcile(ctx, req)
 	assert.NoError(t, err)
-	// Should not requeue for maintenance since we're outside the window
-	assert.Equal(t, reconcile.Result{}, result)
+	// Window is ~2h ahead, so requeue is capped to wake before it opens
+	assert.Equal(t, maxMaintenanceRequeue, result.RequeueAfter)
 
 	// Verify PDB was created
 	pdb := &policyv1.PodDisruptionBudget{}

--- a/internal/controller/maintenance_window.go
+++ b/internal/controller/maintenance_window.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	availabilityv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+)
+
+// maxMaintenanceRequeue bounds the proactive requeue so the controller still wakes
+// at least this often to re-evaluate an upcoming window.
+const maxMaintenanceRequeue = time.Hour
+
+// maintenanceWindowSpan is a normalized, timezone-resolved maintenance window.
+type maintenanceWindowSpan struct {
+	loc   *time.Location
+	start time.Duration         // offset from local midnight
+	end   time.Duration         // offset from local midnight; < start means the window crosses midnight
+	days  map[time.Weekday]bool // empty means every day
+}
+
+// collectMaintenanceWindows normalizes the annotation window and any policy windows
+// into evaluable spans. Unparseable windows are skipped, matching prior best-effort behavior.
+func collectMaintenanceWindows(config *AvailabilityConfig) []maintenanceWindowSpan {
+	if config == nil {
+		return nil
+	}
+	var spans []maintenanceWindowSpan
+	if s, ok := parseAnnotationWindow(config.MaintenanceWindow); ok {
+		spans = append(spans, s)
+	}
+	for i := range config.MaintenanceWindows {
+		if s, ok := parsePolicyWindow(config.MaintenanceWindows[i]); ok {
+			spans = append(spans, s)
+		}
+	}
+	return spans
+}
+
+// parseAnnotationWindow parses the annotation form "HH:MM-HH:MM [Timezone]" (every day).
+func parseAnnotationWindow(window string) (maintenanceWindowSpan, bool) {
+	if window == "" {
+		return maintenanceWindowSpan{}, false
+	}
+	parts := strings.Fields(window)
+	timeRange := parts[0]
+	timezone := "UTC"
+	if len(parts) > 1 {
+		timezone = parts[1]
+	}
+	bounds := strings.Split(timeRange, "-")
+	if len(bounds) != 2 {
+		return maintenanceWindowSpan{}, false
+	}
+	return buildSpan(bounds[0], bounds[1], timezone, nil)
+}
+
+// parsePolicyWindow parses a structured PDBPolicy maintenance window, honoring DaysOfWeek.
+func parsePolicyWindow(w availabilityv1alpha1.MaintenanceWindow) (maintenanceWindowSpan, bool) {
+	timezone := w.Timezone
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	var days map[time.Weekday]bool
+	if len(w.DaysOfWeek) > 0 {
+		days = make(map[time.Weekday]bool, len(w.DaysOfWeek))
+		for _, d := range w.DaysOfWeek {
+			if d >= 0 && d <= 6 {
+				days[time.Weekday(d)] = true
+			}
+		}
+	}
+	return buildSpan(w.Start, w.End, timezone, days)
+}
+
+func buildSpan(start, end, timezone string, days map[time.Weekday]bool) (maintenanceWindowSpan, bool) {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return maintenanceWindowSpan{}, false
+	}
+	startOff, ok := parseHHMM(start)
+	if !ok {
+		return maintenanceWindowSpan{}, false
+	}
+	endOff, ok := parseHHMM(end)
+	if !ok {
+		return maintenanceWindowSpan{}, false
+	}
+	return maintenanceWindowSpan{loc: loc, start: startOff, end: endOff, days: days}, true
+}
+
+func parseHHMM(s string) (time.Duration, bool) {
+	hm := strings.Split(s, ":")
+	if len(hm) != 2 {
+		return 0, false
+	}
+	h, err := strconv.Atoi(hm[0])
+	if err != nil || h < 0 || h > 23 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(hm[1])
+	if err != nil || m < 0 || m > 59 {
+		return 0, false
+	}
+	return time.Duration(h)*time.Hour + time.Duration(m)*time.Minute, true
+}
+
+func (s maintenanceWindowSpan) dayAllowed(wd time.Weekday) bool {
+	if len(s.days) == 0 {
+		return true
+	}
+	return s.days[wd]
+}
+
+// active reports whether now falls inside this window.
+func (s maintenanceWindowSpan) active(now time.Time) bool {
+	local := now.In(s.loc)
+	tod := time.Duration(local.Hour())*time.Hour + time.Duration(local.Minute())*time.Minute
+	if s.start <= s.end {
+		return s.dayAllowed(local.Weekday()) && tod >= s.start && tod < s.end
+	}
+	// Window crosses midnight: the post-midnight tail belongs to the previous day's window.
+	if tod >= s.start {
+		return s.dayAllowed(local.Weekday())
+	}
+	if tod < s.end {
+		return s.dayAllowed(prevWeekday(local.Weekday()))
+	}
+	return false
+}
+
+// nextStart returns the duration from now until this window next opens.
+func (s maintenanceWindowSpan) nextStart(now time.Time) (time.Duration, bool) {
+	local := now.In(s.loc)
+	midnight := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, s.loc)
+	for i := 0; i <= 7; i++ {
+		day := midnight.AddDate(0, 0, i)
+		if !s.dayAllowed(day.Weekday()) {
+			continue
+		}
+		start := day.Add(s.start)
+		if start.After(now) {
+			return start.Sub(now), true
+		}
+	}
+	return 0, false
+}
+
+func prevWeekday(wd time.Weekday) time.Weekday {
+	return time.Weekday((int(wd) + 6) % 7)
+}
+
+// IsInMaintenanceWindow reports whether now is within any window configured on config
+// (annotation window or policy windows).
+func IsInMaintenanceWindow(config *AvailabilityConfig, now time.Time) bool {
+	for _, s := range collectMaintenanceWindows(config) {
+		if s.active(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// durationUntilMaintenanceWindow returns the time until the soonest window opens, and
+// whether any window is configured at all.
+func durationUntilMaintenanceWindow(config *AvailabilityConfig, now time.Time) (time.Duration, bool) {
+	var best time.Duration
+	found := false
+	for _, s := range collectMaintenanceWindows(config) {
+		if d, ok := s.nextStart(now); ok && (!found || d < best) {
+			best, found = d, true
+		}
+	}
+	return best, found
+}
+
+// applyMaintenanceRequeue ensures result wakes the controller at (or before) the next
+// window start, so an idle workload still has its PDB relaxed when the window opens.
+func applyMaintenanceRequeue(result ctrl.Result, config *AvailabilityConfig, now time.Time) ctrl.Result {
+	until, ok := durationUntilMaintenanceWindow(config, now)
+	if !ok {
+		return result
+	}
+	if until > maxMaintenanceRequeue {
+		until = maxMaintenanceRequeue
+	}
+	if result.RequeueAfter == 0 || until < result.RequeueAfter {
+		result.RequeueAfter = until
+	}
+	return result
+}

--- a/internal/controller/maintenance_window_test.go
+++ b/internal/controller/maintenance_window_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clocktesting "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	pdbv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+)
+
+// Wednesday 03:00 UTC - fixed reference so the tests are time-invariant.
+var refNow = time.Date(2026, 6, 24, 3, 0, 0, 0, time.UTC)
+
+func TestIsInMaintenanceWindow_StructuredAndAnnotation(t *testing.T) {
+	today := int(refNow.Weekday())
+	otherDay := (today + 1) % 7
+
+	cases := []struct {
+		name   string
+		config *AvailabilityConfig
+		want   bool
+	}{
+		{
+			name:   "policy window active on matching day",
+			config: &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "02:00", End: "04:00", Timezone: "UTC", DaysOfWeek: []int{today}}}},
+			want:   true,
+		},
+		{
+			name:   "policy window inactive on non-matching day",
+			config: &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "02:00", End: "04:00", DaysOfWeek: []int{otherDay}}}},
+			want:   false,
+		},
+		{
+			name:   "policy window inactive outside time",
+			config: &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "05:00", End: "06:00"}}},
+			want:   false,
+		},
+		{
+			name:   "policy window every day when DaysOfWeek empty",
+			config: &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "02:00", End: "04:00"}}},
+			want:   true,
+		},
+		{
+			name:   "overnight policy window active after midnight",
+			config: &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "22:00", End: "04:00"}}},
+			want:   true,
+		},
+		{
+			name:   "annotation window still honored",
+			config: &AvailabilityConfig{MaintenanceWindow: "02:00-04:00 UTC"},
+			want:   true,
+		},
+		{
+			name:   "no window configured",
+			config: &AvailabilityConfig{},
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsInMaintenanceWindow(tc.config, refNow))
+		})
+	}
+}
+
+func TestDurationUntilMaintenanceWindow(t *testing.T) {
+	// Window later today (05:00-06:00) is 2h away from 03:00.
+	cfg := &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "05:00", End: "06:00"}}}
+	d, ok := durationUntilMaintenanceWindow(cfg, refNow)
+	require.True(t, ok)
+	assert.Equal(t, 2*time.Hour, d)
+
+	// A window that already opened earlier today rolls to the next day.
+	cfg = &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "02:00", End: "02:30"}}}
+	d, ok = durationUntilMaintenanceWindow(cfg, refNow)
+	require.True(t, ok)
+	assert.Equal(t, 23*time.Hour, d)
+
+	// No window configured.
+	_, ok = durationUntilMaintenanceWindow(&AvailabilityConfig{}, refNow)
+	assert.False(t, ok)
+}
+
+func TestApplyMaintenanceRequeue_CapsAndKeepsSooner(t *testing.T) {
+	// Next window is 2h out, capped to the heartbeat.
+	cfg := &AvailabilityConfig{MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{{Start: "05:00", End: "06:00"}}}
+	got := applyMaintenanceRequeue(reconcile.Result{}, cfg, refNow)
+	assert.Equal(t, maxMaintenanceRequeue, got.RequeueAfter)
+
+	// An existing sooner requeue is preserved.
+	got = applyMaintenanceRequeue(reconcile.Result{RequeueAfter: time.Second}, cfg, refNow)
+	assert.Equal(t, time.Second, got.RequeueAfter)
+
+	// No window leaves the result untouched.
+	got = applyMaintenanceRequeue(reconcile.Result{}, &AvailabilityConfig{}, refNow)
+	assert.Zero(t, got.RequeueAfter)
+}
+
+// TestDeploymentReconciler_PolicyMaintenanceWindow proves a PDBPolicy-level maintenance
+// window is now evaluated (previously ignored) and is time-driven via the injected clock.
+func TestDeploymentReconciler_PolicyMaintenanceWindow(t *testing.T) {
+	ctx := context.Background()
+
+	policy := &pdbv1alpha1.PDBPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "mw-policy", Namespace: "default"},
+		Spec: pdbv1alpha1.PDBPolicySpec{
+			AvailabilityClass: pdbv1alpha1.Standard,
+			WorkloadSelector:  pdbv1alpha1.WorkloadSelector{MatchLabels: map[string]string{"app": "mw"}},
+			MaintenanceWindows: []pdbv1alpha1.MaintenanceWindow{
+				{Start: "02:00", End: "04:00", Timezone: "UTC"},
+			},
+		},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mw",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "mw"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "mw"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "mw"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+			},
+		},
+	}
+
+	tr := CreateTestReconcilers(policy, deployment)
+	r := tr.DeploymentReconciler
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "mw", Namespace: "default"}}
+	pdbKey := types.NamespacedName{Name: "mw-pdb", Namespace: "default"}
+
+	// Clock inside the policy window: PDB must be relaxed, i.e. not enforced.
+	r.Clock = clocktesting.NewFakeClock(refNow)
+	_, err := r.Reconcile(ctx, req) // adds finalizer
+	require.NoError(t, err)
+	result, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, time.Minute, result.RequeueAfter, "maintenance branch requeues every minute")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, pdbKey, pdb)
+	assert.True(t, apierrors.IsNotFound(err), "no PDB should be enforced during the policy maintenance window")
+
+	// Clock outside the window: PDB is created normally.
+	r.Clock = clocktesting.NewFakeClock(time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC))
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, tr.Client.Get(ctx, pdbKey, pdb))
+}
+
+// TestHasStateChanged_PropagatesGetError covers the state tracker surfacing a transient
+// client error instead of silently treating the PDB as absent.
+func TestHasStateChanged_PropagatesGetError(t *testing.T) {
+	ctx := context.Background()
+	scheme := SetupTestScheme()
+	boom := errors.New("api server unavailable")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*policyv1.PodDisruptionBudget); ok {
+				return boom
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+	}).Build()
+
+	tracker := NewWorkloadStateTracker()
+	w := &deploymentWorkload{&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "err", Namespace: "default"},
+	}}
+
+	changed, err := tracker.HasStateChanged(ctx, c, w, &AvailabilityConfig{})
+	require.ErrorIs(t, err, boom)
+	assert.False(t, changed)
+}

--- a/internal/controller/pdbpolicy_controller.go
+++ b/internal/controller/pdbpolicy_controller.go
@@ -239,7 +239,7 @@ func (r *PDBPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		policy.Finalizers = append(policy.Finalizers, availabilityPolicyFinalizer)
 		if err := RetryUpdateWithBackoff(ctx, r.Client, policy, DefaultRetryConfig()); err != nil {
 			reconcileErr = err
-			logger.Error(err, "Failed to remove finalizer after retries", map[string]any{
+			logger.Error(err, "Failed to add finalizer after retries", map[string]any{
 				"error_type": GetErrorType(err),
 			})
 			return ctrl.Result{}, err

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sevents "k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,8 +58,17 @@ type StatefulSetReconciler struct {
 	Events      *events.EventRecorder
 	PolicyCache *cache.PolicyCache
 	Config      *SharedConfig
+	// Clock is injectable for deterministic maintenance-window tests; defaults to real time.
+	Clock clock.PassiveClock
 
 	tracker *WorkloadStateTracker
+}
+
+func (r *StatefulSetReconciler) now() time.Time {
+	if r.Clock != nil {
+		return r.Clock.Now()
+	}
+	return time.Now()
 }
 
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
@@ -183,7 +193,12 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	stateChanged := r.tracker.HasStateChanged(ctx, r.Client, w, config)
+	stateChanged, err := r.tracker.HasStateChanged(ctx, r.Client, w, config)
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "Failed to check statefulset state changes, proceeding with reconciliation", map[string]any{})
+		stateChanged = true
+	}
 
 	logger.V(1).Info("Change detection result",
 		"stateChanged", stateChanged,
@@ -229,7 +244,7 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		attribute.String("source", config.Source),
 	)
 
-	if IsInMaintenanceWindow(config, r.PolicyCache, log.FromContext(ctx)) {
+	if IsInMaintenanceWindow(config, r.now()) {
 		logger.Info("In maintenance window, temporarily relaxing PDB", map[string]any{
 			"maintenanceWindow": config.MaintenanceWindow,
 		})
@@ -257,7 +272,9 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	).Set(1)
 
 	metrics.UpdateComplianceStatus(sts.Namespace, sts.Name, true, "managed")
-	r.tracker.UpdateState(ctx, r.Client, w, config)
+	if err := r.tracker.UpdateState(ctx, r.Client, w, config); err != nil {
+		logger.Error(err, "Failed to update statefulset state cache", map[string]any{})
+	}
 
 	logger.Info("Successfully reconciled PDB", map[string]any{
 		"availabilityClass": config.AvailabilityClass,
@@ -265,7 +282,8 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"reconcileID":       reconcileID,
 	})
 
-	return result, nil
+	// wake up proactively when a maintenance window is due to open
+	return applyMaintenanceRequeue(result, config, r.now()), nil
 }
 
 // policyMatchesStatefulSet checks if a policy matches a StatefulSet.

--- a/internal/controller/statefulset_controller_test.go
+++ b/internal/controller/statefulset_controller_test.go
@@ -459,7 +459,8 @@ func TestStatefulSetReconciler_MaintenanceWindow(t *testing.T) {
 	// Outside maintenance window: PDB created normally
 	result, err = reconciler.Reconcile(ctx, req)
 	assert.NoError(t, err)
-	assert.Equal(t, reconcile.Result{}, result)
+	// Window is ~2h ahead, so requeue is capped to wake before it opens
+	assert.Equal(t, maxMaintenanceRequeue, result.RequeueAfter)
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err = tr.Client.Get(ctx, types.NamespacedName{

--- a/internal/controller/workload.go
+++ b/internal/controller/workload.go
@@ -121,26 +121,34 @@ func NewWorkloadStateTracker() *WorkloadStateTracker {
 	return &WorkloadStateTracker{state: make(map[types.NamespacedName]string)}
 }
 
-func (t *WorkloadStateTracker) HasStateChanged(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) bool {
+func (t *WorkloadStateTracker) HasStateChanged(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) (bool, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.state == nil {
-		return true
+		return true, nil
 	}
 	key := types.NamespacedName{Name: w.GetName(), Namespace: w.GetNamespace()}
-	current := calculateWorkloadFingerprint(ctx, c, w, config)
+	current, err := calculateWorkloadFingerprint(ctx, c, w, config)
+	if err != nil {
+		return false, err
+	}
 	last, exists := t.state[key]
-	return !exists || current != last
+	return !exists || current != last, nil
 }
 
-func (t *WorkloadStateTracker) UpdateState(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) {
+func (t *WorkloadStateTracker) UpdateState(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.state == nil {
 		t.state = make(map[types.NamespacedName]string)
 	}
 	key := types.NamespacedName{Name: w.GetName(), Namespace: w.GetNamespace()}
-	t.state[key] = calculateWorkloadFingerprint(ctx, c, w, config)
+	current, err := calculateWorkloadFingerprint(ctx, c, w, config)
+	if err != nil {
+		return err
+	}
+	t.state[key] = current
+	return nil
 }
 
 func (t *WorkloadStateTracker) ClearState(w WorkloadAccessor) {
@@ -149,7 +157,7 @@ func (t *WorkloadStateTracker) ClearState(w WorkloadAccessor) {
 	delete(t.state, types.NamespacedName{Name: w.GetName(), Namespace: w.GetNamespace()})
 }
 
-func calculateWorkloadFingerprint(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) string {
+func calculateWorkloadFingerprint(ctx context.Context, c client.Client, w WorkloadAccessor, config *AvailabilityConfig) (string, error) {
 	h := sha256.New()
 	_, _ = fmt.Fprintf(h, "generation:%d", w.GetGeneration())
 	_, _ = fmt.Fprintf(h, "replicas:%d", w.GetReplicas())
@@ -195,8 +203,10 @@ func calculateWorkloadFingerprint(ctx context.Context, c client.Client, w Worklo
 				_, _ = fmt.Fprintf(h, "pdb:selector:%s=%s", key, value)
 			}
 		}
-	} else {
+	} else if errors.IsNotFound(err) {
 		_, _ = h.Write([]byte("pdb:exists=false"))
+	} else {
+		return "", err
 	}
 
 	if config != nil {
@@ -208,7 +218,7 @@ func calculateWorkloadFingerprint(ctx context.Context, c client.Client, w Worklo
 		}
 	}
 
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func IsValidAvailabilityClass(class availabilityv1alpha1.AvailabilityClass) bool {
@@ -519,7 +529,12 @@ func GetAvailabilityConfigWithCache(ctx context.Context, c client.Client, policy
 	if err != nil {
 		return nil, err
 	}
-	return ResolveConfiguration(w, annotationConfig, policyConfig, matchedPolicy, eventsRecorder, logger), nil
+	finalConfig := ResolveConfiguration(w, annotationConfig, policyConfig, matchedPolicy, eventsRecorder, logger)
+	// carry policy maintenance windows onto whichever config wins resolution
+	if finalConfig != nil && matchedPolicy != nil {
+		finalConfig.MaintenanceWindows = matchedPolicy.Spec.MaintenanceWindows
+	}
+	return finalConfig, nil
 }
 
 func ResolveConfiguration(
@@ -613,55 +628,6 @@ func ResolveConfiguration(
 		metrics.RecordEnforcementDecision("unknown", "defaulting-to-policy", w.GetNamespace())
 		return policyConfig
 	}
-}
-
-func IsInMaintenanceWindow(config *AvailabilityConfig, policyCache *cache.PolicyCache, _ logr.Logger) bool {
-	if config.MaintenanceWindow == "" {
-		return false
-	}
-	cacheKey := fmt.Sprintf("maintenance-window-%s", config.MaintenanceWindow)
-	if policyCache != nil {
-		if cachedResult, found := policyCache.GetMaintenanceWindow(cacheKey); found {
-			return cachedResult
-		}
-	}
-	parts := strings.Fields(config.MaintenanceWindow)
-	if len(parts) < 1 {
-		return false
-	}
-	timeRange := parts[0]
-	timezone := "UTC"
-	if len(parts) > 1 {
-		timezone = parts[1]
-	}
-	timeParts := strings.Split(timeRange, "-")
-	if len(timeParts) != 2 {
-		return false
-	}
-	location, err := time.LoadLocation(timezone)
-	if err != nil {
-		return false
-	}
-	now := time.Now().In(location)
-	today := now.Format("2006-01-02")
-	todayStart, err := time.ParseInLocation("2006-01-02 15:04", fmt.Sprintf("%s %s", today, timeParts[0]), location)
-	if err != nil {
-		return false
-	}
-	todayEnd, err := time.ParseInLocation("2006-01-02 15:04", fmt.Sprintf("%s %s", today, timeParts[1]), location)
-	if err != nil {
-		return false
-	}
-	var result bool
-	if todayEnd.Before(todayStart) {
-		result = now.After(todayStart) || now.Before(todayEnd)
-	} else {
-		result = now.After(todayStart) && now.Before(todayEnd)
-	}
-	if policyCache != nil {
-		policyCache.SetMaintenanceWindow(cacheKey, result, 1*time.Minute)
-	}
-	return result
 }
 
 func RemovePDBTemporarily(ctx context.Context, c client.Client, w WorkloadAccessor, logger logr.Logger) error {


### PR DESCRIPTION
## Summary

Fixes a set of issues found in a code evaluation of the operator. The headline is a functional bug: **PDBPolicy-level maintenance windows were never evaluated**.

Closes #45, #46, #47, #48, #49, #50.

## Changes

| Issue | Change |
|-------|--------|
| #45 | Policy maintenance windows are now carried onto the resolved config and evaluated. New shared evaluator in `maintenance_window.go` handles timezone, `DaysOfWeek`, multiple windows, and overnight spans (the old code only parsed the annotation string and ignored `DaysOfWeek`). Both controllers use it. |
| #46 | When a workload is outside a configured window, the reconciler requeues to wake at the next window start (capped to an hourly heartbeat), so idle workloads get relaxed on time. |
| #47 | Replaced the hand-rolled O(N^2) insertion sort in the circuit breaker with `slices.Sort`. |
| #48 | Fixed the add-finalizer error log that wrongly said "remove finalizer". |
| #49 | `WorkloadStateTracker` and the deployment fingerprint now propagate transient client `Get` errors (distinguishing `NotFound`) instead of silently treating the PDB as absent. |
| #50 | Reconcilers read time via an injectable `k8s.io/utils/clock.PassiveClock`, making maintenance-window behavior deterministically testable. |

The #3 large refactor of `deployment_controller.go` from the report is intentionally **out of scope** here.

## Testing

- `make test` green; `golangci-lint` 0 issues; `gofmt`/`go vet` clean.
- 5 new unit tests (structured/overnight/day-of-week windows, next-window duration, requeue capping, policy-window reconcile with a fake clock, state-tracker error propagation).
- **Live verification on kind (k8s 1.35):** a `PDBPolicy` with an active maintenance window -> operator creates **no** PDB; flipping the window to inactive -> PDB appears with the expected `minAvailable`. Previously the policy window was ignored and a PDB was always created.

## Found while testing (separate, pre-existing, filed)

- #51: `make deploy` installs webhook configs but the manager runs with webhooks disabled, blocking `PDBPolicy` creation via kustomize.
- #52: tracing init fails on conflicting OpenTelemetry schema URLs.