### PR TITLE
fix: align OpenTelemetry semconv schema with SDK (tracing init failure)

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -60,17 +60,17 @@ func TestInitTracingWithInvalidJaegerEndpoint(t *testing.T) {
 }
 
 func TestInitTracingWithOTLPEndpoint(t *testing.T) {
-	// Set OTLP endpoint (connection will fail but exporter should be created)
+	// Set OTLP endpoint; exporter creation is lazy and does not dial.
 	_ = os.Setenv("OTLP_ENDPOINT", "localhost:4317")
 	defer func() { _ = os.Unsetenv("OTLP_ENDPOINT") }()
 
+	// Regression for the schema-URL conflict: the resource is built via
+	// resource.Merge(resource.Default(), resource.NewWithAttributes(semconv.SchemaURL, ...)).
+	// If the semconv import's schema URL differs from the SDK's, Merge errors.
 	cleanup, err := InitTracing(context.Background(), "test-service")
-
-	// Should succeed - exporter creation doesn't require connection
-	if err == nil {
-		require.NotNil(t, cleanup)
-		cleanup()
-	}
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup()
 }
 
 func TestStartSpan(t *testing.T) {


### PR DESCRIPTION
## Problem

At startup the operator logs and then runs without tracing:

```
"Failed to initialize tracing, continuing without it":
"conflicting Schema URL: https://opentelemetry.io/schemas/1.41.0 and https://opentelemetry.io/schemas/1.39.0"
```

## Root cause

`internal/tracing/tracing.go` builds the resource via `resource.Merge(resource.Default(), resource.NewWithAttributes(semconv.SchemaURL, ...))`. The import was `semconv/v1.39.0`, but `resource.Default()` in `go.opentelemetry.io/otel/sdk v1.44.0` uses `semconv/v1.41.0` (`sdk/resource/builtin.go`). `resource.Merge` errors when two resources carry different non-empty schema URLs.

## Fix

Bump the `semconv` import to `v1.41.0` to match the SDK (the package is already part of `otel v1.44.0`; `go.mod`/`go.sum` unchanged).

## Testing

`TestInitTracingWithOTLPEndpoint` exercised this path but only asserted `if err == nil { ... }`, so it passed silently while broken. Strengthened it to `require.NoError`. Verified it **fails on v1.39.0** with the exact production error and **passes on v1.41.0**.

Closes #52