### PR TITLE
fix: enable webhook server in default kustomize deploy (unblocks PDBPolicy creation)

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,6 +31,15 @@ patches:
 - path: manager_webhook_patch.yaml
   target:
     kind: Deployment
+# [WEBHOOK] Enable the webhook server so the registered admission webhooks are served.
+# Pairs with ../webhook + ../certmanager + the cert mount above; comment out together to disable.
+- target:
+    kind: Deployment
+    name: controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --enable-webhook
 
 replacements:
 # [CERTMANAGER] cert-manager CA injection for webhooks


### PR DESCRIPTION
## Problem

A fresh `make deploy` (kustomize `config/default`) makes every `PDBPolicy` create fail:

```
Internal error occurred: failed calling webhook "pdbpolicy.availability.pdboperator.io":
... dial tcp ...:443: connect: connection refused
```

## Root cause

`config/default/kustomization.yaml` has the `[WEBHOOK]` and `[CERTMANAGER]` sections enabled: it pulls in `../webhook` (the Validating/Mutating configs, `failurePolicy: Fail`), `../certmanager` (serving cert), and `manager_webhook_patch.yaml` (mounts the cert). But the manager args were only `--metrics-bind-address`, `--leader-elect`, `--health-probe-bind-address` - no `--enable-webhook`, which defaults to `false` in `cmd/main.go`. So `webhookEnabled:false`, nothing listens on `:9443`, and the admission webhooks reject all `PDBPolicy` writes.

This is a half-completed webhook enablement: the resources were uncommented but the flag was never added. The Helm chart sets `--enable-webhook`, so only the kustomize path was affected.

## Fix

Append `--enable-webhook` to the manager args via a JSON patch in the `[WEBHOOK]` section, so it is enabled/disabled together with the webhook resources (matching the Kubebuilder convention of toggling all webhook parts together). The default already provisions a cert-manager `Certificate`, so this adds no new dependency.

## Verification

`kustomize build config/default` now renders the manager with:

```yaml
args:
- --metrics-bind-address=:8443
- --leader-elect
- --health-probe-bind-address=:8081
- --enable-webhook
```

with both webhook configurations and the cert mount present. (Found and root-caused while smoke-testing #45 on kind.)

## Alternative considered

Making the default webhook-free (Kubebuilder's out-of-the-box state) and shipping an opt-in webhook overlay. Not chosen here because the repo had already committed to a webhook-on default (cert-manager + webhook resources uncommented); this PR makes that existing intent consistent with the smallest change. Happy to switch to the overlay approach if maintainers prefer a cert-manager-free default.

Closes #51