### PR TITLE
fix(ci): repair e2e startup failure introduced by helm/kind-action

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -40,9 +40,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Install kind
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
-        with:
-          install_only: true
+        env:
+          KIND_VERSION: v0.32.0
+        run: |
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
 
       - name: Verify kind installation
         run: kind version


### PR DESCRIPTION
## Problem

After #57 merged, the **E2E Tests** workflow fails at startup (0s, "this run failed because of a workflow file issue") and never runs. On `main` it went from passing (~5 min) before #57 to `startup_failure` immediately after.

## Root cause

#57 replaced the kind install with `helm/kind-action` pinned at the `v1` tag. That commit's `action.yml` declares `runs.using: "node24"`, a runtime the current GitHub-hosted runners reject — so the workflow can't start. (Inputs like `install_only` were valid; the failure is the action runtime, not the inputs.)

## Fix

Restore a plain `run:` install but **pin the kind version** (`v0.32.0`) instead of the original floating `…/dl/latest/`. This keeps the reproducibility goal that motivated the #57 change, without depending on a third-party action's node runtime.

```yaml
- name: Install kind
  env:
    KIND_VERSION: v0.32.0
  run: |
    curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
    chmod +x ./kind
    sudo mv ./kind /usr/local/bin/kind
```

zizmor clean; version passed via `env` (no `${{ }}` in `run:`). This PR edits `test-e2e.yml`, so the e2e runs on the PR and validates the fix end to end.

## Lesson
`helm/kind-action@v1` had moved to a `node24` runtime - exactly the "recent commit on a moving major tag" red flag. Pinning to a specific node20-era release would also work, but the run-step install removes the dependency entirely.