### PR TITLE
Bump Go to 1.26.5 to fix GO-2026-5856 (CVE-2026-42505) in crypto/tls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pdb-operator/pdb-operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## What

Bump the `go` directive in `go.mod` from `1.26.4` to `1.26.5`.

## Why

The scheduled Govulncheck workflow is failing on [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) / CVE-2026-42505, a `crypto/tls` (Encrypted Client Hello / PSK de-anonymization) vulnerability present in `go1.26.4` and fixed in `go1.26.5`. The workflow provisions Go via `go-version-file: go.mod`, so bumping the directive pulls in the patched standard library. No code or dependency changes.

## Verify

- [x] `go build ./...` passes
- [x] `govulncheck ./...` reports **No vulnerabilities found**
- [ ] Govulncheck check green on this PR

Closes #66