### PR TITLE
Replace retired Go Report Card badge with lint status

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
-          args: --verbose --no-progress --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' '**/*.md'
+          args: --verbose --no-progress --max-retries 5 --retry-wait-time 2 --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' '**/*.md'
           fail: true

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
   <a href="https://github.com/pdb-operator/pdb-operator/actions/workflows/test.yml?query=branch%3Amain">
     <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/pdb-operator/pdb-operator/test.yml?branch=main&style=for-the-badge&label=tests">
   </a>
-  <a href="https://goreportcard.com/report/github.com/pdb-operator/pdb-operator">
-    <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/pdb-operator/pdb-operator?style=for-the-badge">
+  <a href="https://github.com/pdb-operator/pdb-operator/actions/workflows/lint.yml?query=branch%3Amain">
+    <img alt="Lint Status" src="https://img.shields.io/github/actions/workflow/status/pdb-operator/pdb-operator/lint.yml?branch=main&style=for-the-badge&label=lint">
   </a>
   <a href="https://github.com/pdb-operator/pdb-operator/releases">
     <img alt="Latest Release" src="https://img.shields.io/github/v/release/pdb-operator/pdb-operator?include_prereleases&style=for-the-badge">


### PR DESCRIPTION
## What

Swap the README's Go Report Card badge for a golangci-lint workflow status badge.

## Why

[Go Report Card has been sunset](https://goreportcard.com/report/github.com/pdb-operator/pdb-operator); its badge now renders as `go report | retired`. The project itself points to **golangci-lint** as the successor, which this repo already runs in CI (`.github/workflows/lint.yml`), so the new badge reflects real, current code-quality signal.

## Change

```diff
- Go Report Card badge -> goreportcard.com (retired)
+ Lint badge -> shields.io status of lint.yml on main
```