### PR TITLE
fix(deps): bump google.golang.org/grpc to v1.82.1 for GO-2026-6061

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Fixes #75

## What

Bumps the indirect dependency `google.golang.org/grpc` from v1.81.1 to v1.82.1.

## Why

The scheduled `Govulncheck` workflow on `main` fails with exit code 3 ([run 30366601931](https://github.com/pdb-operator/pdb-operator/actions/runs/30366601931)):

```
Vulnerability #1: GO-2026-6061
    Found in: google.golang.org/grpc@v1.81.1
    Fixed in: google.golang.org/grpc@v1.82.1
```

GO-2026-6061 (GHSA-hrxh-6v49-42gf, no CVE assigned): vulnerabilities in the xDS RBAC authorization engine (`internal/xds/rbac`) and the HTTP/2 transport server implementation (`internal/transport`). Govulncheck flags the path as reachable via the OTLP exporter's gRPC client transport: `internal/tracing/tracing.go:92` -> `trace.WithBatcher` -> `transport.ClientStream.*`.

Practical exposure is low: the operator is a gRPC *client* (OTLP trace export) and does not run an xDS-configured gRPC server, so the RBAC engine and `http2Server` symbols are not exercised at runtime. The job gates on govulncheck regardless.

Only the one module changes. No direct dependencies change.

## Verification

| Check | Result |
| --- | --- |
| `govulncheck ./...` | `No vulnerabilities found.` |
| `make test` | all packages pass |

## Note

Dependabot PRs #73 and #74 also touch `go.mod`. Whichever merges second will need a trivial rebase.
