### PR TITLE
fix(security): bump Go to 1.26.6 for six stdlib vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Bumped Go to 1.26.6 to resolve six standard library vulnerabilities reported by govulncheck: GO-2026-6218 (`net/url`), GO-2026-6091 (`html/template`), GO-2026-6090 (`crypto/tls`), GO-2026-6089 and GO-2026-5026 (`net/http`), GO-2026-5972 (`encoding/asn1`) (#79)
+
 ## [0.3.1] - 2026-07-11
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pdb-operator/pdb-operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.4


### PR DESCRIPTION
Closes #79.

The scheduled Govulncheck run fails on `main` ([run 31803026051](https://github.com/pdb-operator/pdb-operator/actions/runs/31803026051), exit code 3). `go.mod` pinned `go 1.26.5`, and all 10 `setup-go` steps resolve their toolchain with `go-version-file: go.mod`, so CI built against a Go standard library carrying six known vulnerabilities. The run log confirms it: `Setup go version spec 1.26.5`.

## Change

One line in `go.mod`, plus a `CHANGELOG.md` entry. Same shape as #67.

```diff
-go 1.26.5
+go 1.26.6
```

Every finding is standard library, and each reports `Fixed in: <pkg>@go1.26.6`:

| ID | Package |
| --- | --- |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` |

No first-party code change is needed: all six are reached transitively through the stdlib. `Dockerfile:3` uses `golang:1.26` (floating patch) and no `GOTOOLCHAIN` is pinned anywhere, so nothing else needs to change.

## Verification

Run locally on this branch with go1.26.6:

- `govulncheck ./...` -> `No vulnerabilities found. Your code is affected by 0 vulnerabilities.`
- `go build ./...` -> clean
- `go vet ./...` -> clean
- `make test` -> all packages pass (api/v1alpha1, cache, client, controller, events, logging, metrics, tracing)

## Note

`golang.org/x/mod@v0.37.0` still carries GO-2026-6179 / GO-2026-6180, but they are uncalled (module-level only), so govulncheck exits 0. Left to Dependabot.
