### PR TITLE
feat: group-aware PDBs for LeaderWorkerSet (quantize minAvailable to whole inference groups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Group-aware PDBs for LeaderWorkerSet (`leaderworkerset.x-k8s.io/v1`): multi-host inference workloads restart in gangs, so `minAvailable` is quantized to whole groups (`ceil(class% x replicas)` clamped to `replicas - 1`, times `size`). Single-group sets get no PDB plus a Warning event instead of a budget that would permanently block node drains; `size: 1` keeps plain pod-level semantics. The StatefulSet controller now skips LWS-internal StatefulSets (leader and per-group workers, detected by the `leaderworkerset.sigs.k8s.io/name` label) so a workload never matches multiple PDBs, which would make the eviction API fail outright. Support activates only when the LWS CRD is installed (#81)
+
 ### Security
 - Bumped Go to 1.26.6 to resolve six standard library vulnerabilities reported by govulncheck: GO-2026-6218 (`net/url`), GO-2026-6091 (`html/template`), GO-2026-6090 (`crypto/tls`), GO-2026-6089 and GO-2026-5026 (`net/http`), GO-2026-5972 (`encoding/asn1`) (#79)
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,29 @@ metadata:
 
 Security workloads (`pdboperator.io/workload-function: security`) are automatically boosted: `non-critical` becomes 50%, `standard` becomes 75%.
 
+## Group-Aware PDBs for Multi-Host Inference (LeaderWorkerSet)
+
+When the [LeaderWorkerSet](https://lws.sigs.k8s.io/) CRD (`leaderworkerset.x-k8s.io/v1`) is installed, the operator also manages PDBs for LWS workloads such as multi-host vLLM or SGLang deployments. Support is detected at startup; without the CRD the operator runs unchanged.
+
+LWS groups restart as a unit (default `RecreateGroupOnPodRestart`): evicting one pod takes down all `size` pods of its group. A pod-counting percentage both under-protects capacity and can deadlock node drains, so the operator quantizes the budget to whole groups:
+
+```
+desiredGroups = ceil(class% x replicas), clamped to replicas - 1
+minAvailable  = desiredGroups x size
+```
+
+For `replicas: 4, size: 8` under `mission-critical` (90%) this yields `minAvailable: 24`: exactly one group may be disrupted at a time, and a drain always makes progress. Granularity is whole groups, so a 4-group set has only 4 protection steps.
+
+Special cases:
+
+| Shape | Behavior |
+|-------|----------|
+| `replicas: 1` | No PDB is created (any budget would permanently block drains); a Warning event explains why |
+| `size: 1` | Plain pod-level semantics, same as a Deployment |
+| `custom` with absolute `minAvailable` | Rounded up to the next whole group |
+
+The PDB selects on the `leaderworkerset.sigs.k8s.io/name` label, covering leader and worker pods. LWS implements each set as a leader StatefulSet plus per-group worker StatefulSets; the operator's StatefulSet controller skips those (same label) so pods never match more than one PDB, which would make the eviction API reject every eviction.
+
 ## Enforcement Modes
 
 | Mode | Behavior |
@@ -218,6 +241,7 @@ spec:
 | `pdb_operator_pdbs_updated_total` | Counter | PDBs updated |
 | `pdb_operator_pdbs_deleted_total` | Counter | PDBs deleted |
 | `pdb_operator_deployments_managed` | Gauge | Managed deployments per namespace/class |
+| `pdb_operator_leaderworkersets_managed` | Gauge | Managed LeaderWorkerSets per namespace/class |
 | `pdb_operator_policies_active` | Gauge | Active policies per namespace |
 | `pdb_operator_compliance_status` | Gauge | Deployment compliance status |
 | `pdb_operator_maintenance_window_active` | Gauge | Maintenance window active |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -342,6 +342,23 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "StatefulSet")
 		os.Exit(1)
 	}
+	// Register LeaderWorkerSet controller only when the CRD is installed
+	if checkLeaderWorkerSetAvailable(mgr.GetConfig()) {
+		if err := (&pdbcontroller.LeaderWorkerSetReconciler{
+			Client:      circuitBreakerClient,
+			Scheme:      mgr.GetScheme(),
+			Recorder:    mgr.GetEventRecorder("leaderworkerset-controller"),
+			Events:      eventRecorder,
+			PolicyCache: policyCache,
+			Config:      sharedConfig,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "LeaderWorkerSet")
+			os.Exit(1)
+		}
+		setupLog.Info("LeaderWorkerSet support enabled")
+	} else {
+		setupLog.Info("LeaderWorkerSet CRD not found - group-aware PDB support disabled")
+	}
 
 	// Setup webhooks if enabled (with graceful fallback)
 	if enableWebhook {
@@ -623,6 +640,32 @@ func getWatchNamespaceDisplay(namespace string) string {
 		return "all"
 	}
 	return namespace
+}
+
+// checkLeaderWorkerSetAvailable checks if the LeaderWorkerSet CRD is served by the API.
+func checkLeaderWorkerSetAvailable(config *rest.Config) bool {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		setupLog.V(1).Info("leaderworkerset check: failed to create API client",
+			"error", err.Error())
+		return false
+	}
+
+	resources, err := clientset.Discovery().ServerResourcesForGroupVersion(
+		pdbcontroller.LWSGroup + "/" + pdbcontroller.LWSVersion)
+	if err != nil {
+		setupLog.V(1).Info("leaderworkerset check: group version not served",
+			"groupVersion", pdbcontroller.LWSGroup+"/"+pdbcontroller.LWSVersion,
+			"error", err.Error())
+		return false
+	}
+
+	for _, r := range resources.APIResources {
+		if r.Kind == "LeaderWorkerSet" {
+			return true
+		}
+	}
+	return false
 }
 
 // checkCertManagerAvailable checks if cert-manager has provisioned the webhook certificate.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,6 +67,24 @@ rules:
   - patch
   - update
 - apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/internal/controller/leaderworkerset_controller.go
+++ b/internal/controller/leaderworkerset_controller.go
@@ -1,0 +1,501 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sevents "k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	availabilityv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+	"github.com/pdb-operator/pdb-operator/internal/cache"
+	"github.com/pdb-operator/pdb-operator/internal/events"
+	"github.com/pdb-operator/pdb-operator/internal/logging"
+	"github.com/pdb-operator/pdb-operator/internal/metrics"
+	"github.com/pdb-operator/pdb-operator/internal/tracing"
+)
+
+const (
+	kindLeaderWorkerSet      = "LeaderWorkerSet"
+	kindLeaderWorkerSetLower = "leaderworkerset"
+	// LWSGroup is the API group of the LeaderWorkerSet CRD (note: labels use a different prefix).
+	LWSGroup   = "leaderworkerset.x-k8s.io"
+	LWSVersion = "v1"
+	// LWSSetNameLabelKey is the label LWS puts on every pod of a set.
+	LWSSetNameLabelKey = "leaderworkerset.sigs.k8s.io/name"
+)
+
+// LWSGVK is the GroupVersionKind of LeaderWorkerSet.
+var LWSGVK = schema.GroupVersionKind{Group: LWSGroup, Version: LWSVersion, Kind: kindLeaderWorkerSet}
+
+// NewLWSObject returns an empty unstructured LeaderWorkerSet with its GVK set.
+func NewLWSObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(LWSGVK)
+	return u
+}
+
+// lwsWorkload adapts an unstructured LeaderWorkerSet to WorkloadAccessor.
+// GetReplicas returns the number of groups, not pods.
+type lwsWorkload struct{ *unstructured.Unstructured }
+
+func (l *lwsWorkload) GetObject() client.Object          { return l.Unstructured }
+func (l *lwsWorkload) GetName() string                   { return l.Unstructured.GetName() }
+func (l *lwsWorkload) GetNamespace() string              { return l.Unstructured.GetNamespace() }
+func (l *lwsWorkload) GetAnnotations() map[string]string { return l.Unstructured.GetAnnotations() }
+func (l *lwsWorkload) GetLabels() map[string]string      { return l.Unstructured.GetLabels() }
+func (l *lwsWorkload) GetGeneration() int64              { return l.Unstructured.GetGeneration() }
+func (l *lwsWorkload) DeepCopyObject() client.Object     { return l.DeepCopy() }
+func (l *lwsWorkload) Kind() string                      { return kindLeaderWorkerSet }
+func (l *lwsWorkload) KindLower() string                 { return kindLeaderWorkerSetLower }
+
+func (l *lwsWorkload) GetDeletionTimestamp() *metav1.Time {
+	return l.Unstructured.GetDeletionTimestamp()
+}
+
+// GetSelector synthesizes the selector; LWS has no spec.selector but labels every pod with the set name.
+func (l *lwsWorkload) GetSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: map[string]string{LWSSetNameLabelKey: l.GetName()}}
+}
+
+func (l *lwsWorkload) GetReplicas() int32 {
+	if v, found, err := unstructured.NestedInt64(l.Object, "spec", "replicas"); err == nil && found {
+		return int32(v)
+	}
+	return 1
+}
+
+// GroupSize returns spec.leaderWorkerTemplate.size (pods per group, leader included).
+func (l *lwsWorkload) GroupSize() int32 {
+	if v, found, err := unstructured.NestedInt64(l.Object, "spec", "leaderWorkerTemplate", "size"); err == nil && found {
+		return int32(v)
+	}
+	return 1
+}
+
+// QuantizeMinAvailableForGroups converts a pod-level minAvailable into a whole-group
+// integer for gang-restarting workloads: percentages apply to groups (rounded up),
+// absolute values round up to whole groups, and the result is clamped to groups-1
+// so one group always stays drainable.
+func QuantizeMinAvailableForGroups(minAvailable intstr.IntOrString, groups, size int32) intstr.IntOrString {
+	if groups < 2 || size <= 1 {
+		return minAvailable
+	}
+	var desired int32
+	if minAvailable.Type == intstr.String {
+		v, err := intstr.GetScaledValueFromIntOrPercent(&minAvailable, int(groups), true)
+		if err != nil {
+			return minAvailable
+		}
+		desired = int32(v)
+	} else {
+		desired = (minAvailable.IntVal + size - 1) / size
+	}
+	if desired > groups-1 {
+		desired = groups - 1
+	}
+	if desired < 0 {
+		desired = 0
+	}
+	return intstr.FromInt32(desired * size)
+}
+
+// LeaderWorkerSetReconciler reconciles LeaderWorkerSet objects (leaderworkerset.x-k8s.io/v1).
+type LeaderWorkerSetReconciler struct {
+	client.Client
+	Scheme      *runtime.Scheme
+	Recorder    k8sevents.EventRecorder
+	Events      *events.EventRecorder
+	PolicyCache *cache.PolicyCache
+	Config      *SharedConfig
+	// Clock is injectable for deterministic maintenance-window tests; defaults to real time.
+	Clock clock.PassiveClock
+
+	tracker *WorkloadStateTracker
+}
+
+func (r *LeaderWorkerSetReconciler) now() time.Time {
+	if r.Clock != nil {
+		return r.Clock.Now()
+	}
+	return time.Now()
+}
+
+// +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets/finalizers,verbs=get;patch;update
+
+// Reconcile handles LeaderWorkerSet changes and manages corresponding PDBs.
+func (r *LeaderWorkerSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	startTime := time.Now()
+
+	ctx, span := tracing.ReconcileSpan(ctx, kindLeaderWorkerSetLower, req.Namespace, req.Name)
+	defer span.End()
+
+	reconcileID := kindLeaderWorkerSetLower + "-" + uuid.New().String()
+	correlationID := uuid.New().String()
+
+	span.SetAttributes(
+		attribute.String("reconcile.id", reconcileID),
+		attribute.String("correlation.id", correlationID),
+	)
+
+	logger := logging.CreateUnifiedLogger(ctx,
+		"leaderworkerset-pdb", "leaderworkerset-controller", LWSGroup, kindLeaderWorkerSet,
+		kindLeaderWorkerSetLower, req.Name, req.Namespace, reconcileID, correlationID,
+	)
+
+	var reconcileErr error
+	defer func() {
+		duration := time.Since(startTime)
+		metrics.RecordReconciliation(kindLeaderWorkerSetLower, duration, reconcileErr)
+		if reconcileErr != nil {
+			tracing.RecordError(span, reconcileErr, "Reconciliation failed")
+		}
+		result := logging.AuditResultSuccess
+		if reconcileErr != nil {
+			result = logging.AuditResultFailure
+		}
+		logger.Audit("RECONCILE", fmt.Sprintf("%s/%s", req.Namespace, req.Name), kindLeaderWorkerSetLower,
+			req.Namespace, req.Name, result, map[string]interface{}{
+				"controller": kindLeaderWorkerSetLower,
+				"duration":   time.Since(startTime).String(),
+				"durationMs": time.Since(startTime).Milliseconds(),
+			})
+		logger.Info("Reconciliation completed", map[string]any{"duration": time.Since(startTime).String()})
+	}()
+
+	tracing.AddEvent(ctx, "FetchingLeaderWorkerSet", attribute.String("reconcile.id", reconcileID))
+
+	lws := NewLWSObject()
+	if err := r.Get(ctx, req.NamespacedName, lws); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("LeaderWorkerSet not found, ignoring since object must be deleted", map[string]any{})
+			return ctrl.Result{}, nil
+		}
+		reconcileErr = err
+		logger.Error(err, "Failed to get LeaderWorkerSet", map[string]any{})
+		return ctrl.Result{}, err
+	}
+
+	w := &lwsWorkload{lws}
+
+	if w.GetDeletionTimestamp() != nil {
+		logger.Info("LeaderWorkerSet is being deleted", map[string]any{})
+		r.tracker.ClearState(w)
+		tracing.AddEvent(ctx, "DeletingPDB")
+		if err := HandleDeletion(ctx, r.Client, r.Events, w, logger.ToLogr()); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	groups := w.GetReplicas()
+	size := w.GroupSize()
+
+	if groups < 2 {
+		// a single gang-restarting group has no valid PDB: any protection permanently blocks drains
+		logger.Info("Single group, no PDB possible without blocking node drains", map[string]any{
+			"groups": groups, "size": size,
+		})
+		tracing.AddEvent(ctx, "SkippedPDB",
+			attribute.String("reason", "single_group"),
+			attribute.Int("groups", int(groups)),
+		)
+		if err := CleanupPDB(ctx, r.Client, r.Events, w, logger.ToLogr()); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to clean up PDB for single-group LeaderWorkerSet", map[string]any{})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+		}
+		if r.Events != nil {
+			r.Events.Warnf(lws, "LeaderWorkerSetSkipped",
+				"No PDB created for %s: a single group restarts as a unit, so any PDB would permanently block node drains", w.GetName())
+		}
+		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
+		return ctrl.Result{}, nil
+	}
+
+	tracing.AddEvent(ctx, "EvaluatingPolicies")
+
+	config, err := GetAvailabilityConfigWithCache(ctx, r.Client, r.PolicyCache, r.Events, w, logger.ToLogr())
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "Failed to get availability configuration", map[string]any{})
+		return ctrl.Result{}, err
+	}
+
+	if config == nil {
+		logger.Info("No availability configuration found, skipping PDB", map[string]any{})
+		tracing.AddEvent(ctx, "SkippedPDB", attribute.String("reason", "no_availability_configuration"))
+		if r.Events != nil {
+			r.Events.Infof(lws, "LeaderWorkerSetUnmanaged",
+				"LeaderWorkerSet %s has no availability configuration", w.GetName())
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// pods restart in gangs of `size`, so quantize the budget to whole groups
+	config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, groups, size)
+
+	// add the finalizer before the state-change guard so an out-of-band removal is always restored
+	if !controllerutil.ContainsFinalizer(lws, FinalizerPDBCleanup) {
+		patch := client.MergeFrom(lws.DeepCopy())
+		controllerutil.AddFinalizer(lws, FinalizerPDBCleanup)
+		if err := r.Patch(ctx, lws, patch); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to add finalizer", map[string]any{})
+			return ctrl.Result{}, err
+		}
+		logger.Info("Added finalizer for PDB cleanup", map[string]any{})
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	stateChanged, err := r.tracker.HasStateChanged(ctx, r.Client, w, config)
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "Failed to check leaderworkerset state changes, proceeding with reconciliation", map[string]any{})
+		stateChanged = true
+	}
+
+	if !stateChanged {
+		logger.Info("Skipping reconciliation - no state change detected", map[string]any{
+			"availabilityClass": string(config.AvailabilityClass),
+			"source":            config.Source,
+			"policyName":        config.PolicyName,
+			"reason":            "no_state_change",
+			"optimized":         true,
+		})
+		tracing.AddEvent(ctx, "SkippedPDB", attribute.String("reason", "no_state_change"))
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Using availability configuration", map[string]any{
+		"availabilityClass": string(config.AvailabilityClass),
+		"source":            config.Source,
+		"policyName":        config.PolicyName,
+		"groups":            groups,
+		"groupSize":         size,
+		"minAvailable":      config.MinAvailable.String(),
+	})
+
+	span.SetAttributes(
+		attribute.String("config.source", config.Source),
+		attribute.String("config.policy_name", config.PolicyName),
+	)
+
+	tracing.AddEvent(ctx, "ReconcilingPDB",
+		attribute.String("availability_class", string(config.AvailabilityClass)),
+		attribute.String("source", config.Source),
+	)
+
+	if IsInMaintenanceWindow(config, r.now()) {
+		logger.Info("In maintenance window, temporarily relaxing PDB", map[string]any{
+			"maintenanceWindow": config.MaintenanceWindow,
+		})
+		tracing.AddEvent(ctx, "MaintenanceWindowActive",
+			attribute.String("maintenance_window", config.MaintenanceWindow),
+		)
+		if err := RemovePDBTemporarily(ctx, r.Client, w, log.FromContext(ctx)); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to relax PDB for maintenance window", map[string]any{})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+		}
+		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	}
+
+	// never adopt a PDB owned by another kind (e.g. the leader StatefulSet's, pending cleanup)
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	pdbKey := types.NamespacedName{Name: w.GetName() + DefaultPDBSuffix, Namespace: w.GetNamespace()}
+	if err := r.Get(ctx, pdbKey, existingPDB); err == nil {
+		if ref := metav1.GetControllerOf(existingPDB); ref != nil && ref.Kind != kindLeaderWorkerSet {
+			logger.Info("PDB name is held by another owner, waiting for its controller to release it", map[string]any{
+				"pdb": pdbKey.Name, "ownerKind": ref.Kind, "ownerName": ref.Name,
+			})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, nil
+		}
+	}
+
+	result, err := ReconcilePDB(ctx, r.Client, r.Scheme, r.Events, w, config, log.FromContext(ctx))
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "PDB reconciliation failed, will retry", map[string]any{})
+		return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+	}
+
+	metrics.ManagedLeaderWorkerSets.WithLabelValues(
+		w.GetNamespace(),
+		string(config.AvailabilityClass),
+	).Set(1)
+
+	metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), true, "managed")
+	if err := r.tracker.UpdateState(ctx, r.Client, w, config); err != nil {
+		logger.Error(err, "Failed to update leaderworkerset state cache", map[string]any{})
+	}
+
+	logger.Info("Successfully reconciled PDB", map[string]any{
+		"availabilityClass": config.AvailabilityClass,
+		"source":            config.Source,
+		"reconcileID":       reconcileID,
+	})
+
+	// wake up proactively when a maintenance window is due to open
+	return applyMaintenanceRequeue(result, config, r.now()), nil
+}
+
+// SetupWithManager sets up the LeaderWorkerSet controller with the Manager.
+func (r *LeaderWorkerSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	maxConcurrent := 3
+	if r.Config != nil && r.Config.MaxConcurrentReconciles > 0 {
+		maxConcurrent = r.Config.MaxConcurrentReconciles
+	}
+	return r.SetupWithManagerWithOptions(mgr, controller.Options{
+		MaxConcurrentReconciles: maxConcurrent,
+	})
+}
+
+// SetupWithManagerWithOptions sets up the controller with custom options.
+func (r *LeaderWorkerSetReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, opts controller.Options) error {
+	r.tracker = NewWorkloadStateTracker()
+
+	if r.Recorder == nil && mgr != nil {
+		r.Recorder = mgr.GetEventRecorder("leaderworkerset-pdb-controller")
+	}
+	if r.Events == nil && r.Recorder != nil {
+		r.Events = events.NewEventRecorder(r.Recorder)
+	}
+
+	lwsPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return isLWSObject(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !isLWSObject(e.ObjectOld) || !isLWSObject(e.ObjectNew) {
+				return false
+			}
+			if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
+				return e.ObjectOld.GetDeletionTimestamp() == nil && e.ObjectNew.GetDeletionTimestamp() != nil
+			}
+			return true
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	pdbPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			pdb, ok := e.ObjectNew.(*policyv1.PodDisruptionBudget)
+			if !ok {
+				return false
+			}
+			if labels := pdb.GetLabels(); labels != nil {
+				if labels[LabelManagedBy] == OperatorName {
+					oldPDB := e.ObjectOld.(*policyv1.PodDisruptionBudget)
+					return !isPDBUpdateByUs(oldPDB, pdb)
+				}
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			pdb, ok := e.Object.(*policyv1.PodDisruptionBudget)
+			if !ok {
+				return false
+			}
+			if labels := pdb.GetLabels(); labels != nil {
+				return labels[LabelManagedBy] == OperatorName
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	pdbToLWSHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		pdb, ok := obj.(*policyv1.PodDisruptionBudget)
+		if !ok {
+			return nil
+		}
+		if labels := pdb.GetLabels(); labels == nil || labels[LabelManagedBy] != OperatorName {
+			return nil
+		}
+		// only enqueue for PDBs actually owned by a LeaderWorkerSet, else other kinds double reconcile traffic
+		ownerRef := metav1.GetControllerOf(pdb)
+		if ownerRef == nil || ownerRef.Kind != kindLeaderWorkerSet {
+			return nil
+		}
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{Name: ownerRef.Name, Namespace: pdb.Namespace},
+		}}
+	})
+
+	policyHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		policy, ok := obj.(*availabilityv1alpha1.PDBPolicy)
+		if !ok {
+			return nil
+		}
+		logger := log.FromContext(ctx)
+		lwsList := &unstructured.UnstructuredList{}
+		lwsList.SetGroupVersionKind(LWSGVK.GroupVersion().WithKind(kindLeaderWorkerSet + "List"))
+		if err := r.List(ctx, lwsList); err != nil {
+			logger.Error(err, "Failed to list LeaderWorkerSets for policy change")
+			return nil
+		}
+		var requests []ctrl.Request
+		for i := range lwsList.Items {
+			if PolicyMatchesWorkload(policy, &lwsWorkload{&lwsList.Items[i]}) {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{Name: lwsList.Items[i].GetName(), Namespace: lwsList.Items[i].GetNamespace()},
+				})
+			}
+		}
+		logger.V(2).Info("Policy change affects LeaderWorkerSets",
+			"policy", policy.Name, "affectedLeaderWorkerSets", len(requests))
+		return requests
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("leaderworkerset-pdb").
+		For(NewLWSObject(), builder.WithPredicates(lwsPredicate)).
+		Watches(&policyv1.PodDisruptionBudget{}, pdbToLWSHandler, builder.WithPredicates(pdbPredicate)).
+		Watches(&availabilityv1alpha1.PDBPolicy{}, policyHandler).
+		WithOptions(opts).
+		Complete(r)
+}
+
+func isLWSObject(obj client.Object) bool {
+	u, ok := obj.(*unstructured.Unstructured)
+	return ok && u.GroupVersionKind() == LWSGVK
+}

--- a/internal/controller/leaderworkerset_controller_test.go
+++ b/internal/controller/leaderworkerset_controller_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sevents "k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	pdbv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+)
+
+// newTestLWS builds a basic unstructured LeaderWorkerSet for tests.
+//
+//nolint:unparam // namespace parameter allows tests to use non-default namespaces
+func newTestLWS(name, namespace string, replicas, size int64, annotations, labels map[string]string) *unstructured.Unstructured {
+	u := NewLWSObject()
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetAnnotations(annotations)
+	u.SetLabels(labels)
+	u.SetGeneration(1)
+	_ = unstructured.SetNestedField(u.Object, replicas, "spec", "replicas")
+	_ = unstructured.SetNestedField(u.Object, size, "spec", "leaderWorkerTemplate", "size")
+	return u
+}
+
+func newLWSTestReconciler(tr *TestReconcilers) *LeaderWorkerSetReconciler {
+	return &LeaderWorkerSetReconciler{
+		Client:   tr.Client,
+		Scheme:   tr.Scheme,
+		Recorder: tr.StatefulSetReconciler.Recorder,
+		Events:   tr.EventRecorder,
+		tracker:  NewWorkloadStateTracker(),
+	}
+}
+
+func TestQuantizeMinAvailableForGroups(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     intstr.IntOrString
+		groups int32
+		size   int32
+		want   string
+	}{
+		{"percent exact multiple", intstr.FromString("50%"), 4, 8, "16"},
+		{"percent clamped to groups-1", intstr.FromString("90%"), 4, 8, "24"},
+		{"percent clamped two groups", intstr.FromString("90%"), 2, 8, "8"},
+		{"percent rounds up to one group", intstr.FromString("20%"), 4, 8, "8"},
+		{"absolute pods rounds up to group", intstr.FromInt32(12), 4, 8, "16"},
+		{"absolute pods clamped", intstr.FromInt32(32), 4, 8, "24"},
+		{"negative absolute clamps to zero", intstr.FromInt32(-5), 4, 8, "0"},
+		{"size one passes through", intstr.FromString("90%"), 4, 1, "90%"},
+		{"single group passes through", intstr.FromString("90%"), 1, 8, "90%"},
+		{"invalid string passes through", intstr.FromString("garbage"), 4, 8, "garbage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := QuantizeMinAvailableForGroups(tt.in, tt.groups, tt.size)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestLWSReconciler_PolicyBasedPDB_Quantized(t *testing.T) {
+	ctx := context.Background()
+
+	lws := newTestLWS("vllm", "default", 4, 8, nil, map[string]string{"tier": "inference"})
+	policy := &pdbv1alpha1.PDBPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inference-policy",
+			Namespace: "default",
+		},
+		Spec: pdbv1alpha1.PDBPolicySpec{
+			AvailabilityClass: pdbv1alpha1.MissionCritical,
+			WorkloadSelector: pdbv1alpha1.WorkloadSelector{
+				MatchLabels: map[string]string{"tier": "inference"},
+			},
+			Priority: 10,
+		},
+	}
+
+	tr := CreateTestReconcilers(lws, policy)
+	reconciler := newLWSTestReconciler(tr)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "vllm", Namespace: "default"},
+	}
+
+	// First reconciliation adds finalizer
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{Requeue: true}, result)
+
+	updatedLWS := NewLWSObject()
+	err = tr.Client.Get(ctx, req.NamespacedName, updatedLWS)
+	require.NoError(t, err)
+	assert.Contains(t, updatedLWS.GetFinalizers(), FinalizerPDBCleanup, "Finalizer should be added")
+
+	// Second reconciliation creates PDB
+	_, err = reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, types.NamespacedName{Name: "vllm-pdb", Namespace: "default"}, pdb)
+	require.NoError(t, err, "PDB should be created")
+
+	// 90% of 4 groups rounds up to 4, clamped to 3 groups x 8 pods = 24
+	assert.Equal(t, "24", pdb.Spec.MinAvailable.String())
+	assert.Equal(t, map[string]string{LWSSetNameLabelKey: "vllm"}, pdb.Spec.Selector.MatchLabels)
+
+	require.Len(t, pdb.OwnerReferences, 1)
+	assert.Equal(t, kindLeaderWorkerSet, pdb.OwnerReferences[0].Kind)
+	assert.Equal(t, "vllm", pdb.OwnerReferences[0].Name)
+	assert.Equal(t, LWSGroup+"/"+LWSVersion, pdb.OwnerReferences[0].APIVersion)
+}
+
+func TestLWSReconciler_SingleGroup_NoPDB(t *testing.T) {
+	ctx := context.Background()
+
+	lws := newTestLWS("big-model", "default", 1, 8, map[string]string{
+		AnnotationAvailabilityClass: "mission-critical",
+	}, nil)
+
+	tr := CreateTestReconcilers(lws)
+	reconciler := newLWSTestReconciler(tr)
+	fakeRecorder := reconciler.Recorder.(*k8sevents.FakeRecorder)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "big-model", Namespace: "default"},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, types.NamespacedName{Name: "big-model-pdb", Namespace: "default"}, pdb)
+	assert.True(t, errors.IsNotFound(err), "No PDB should be created for a single group")
+
+	select {
+	case event := <-fakeRecorder.Events:
+		assert.Contains(t, event, "Warning")
+		assert.Contains(t, event, "LeaderWorkerSetSkipped")
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Expected a LeaderWorkerSetSkipped warning event")
+	}
+}
+
+func TestLWSReconciler_SizeOne_PodLevel(t *testing.T) {
+	ctx := context.Background()
+
+	lws := newTestLWS("flat", "default", 3, 1, map[string]string{
+		AnnotationAvailabilityClass: "high-availability",
+	}, nil)
+
+	tr := CreateTestReconcilers(lws)
+	reconciler := newLWSTestReconciler(tr)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "flat", Namespace: "default"},
+	}
+
+	_, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, types.NamespacedName{Name: "flat-pdb", Namespace: "default"}, pdb)
+	require.NoError(t, err, "PDB should be created")
+	assert.Equal(t, "75%", pdb.Spec.MinAvailable.String(), "size=1 keeps pod-level percentage semantics")
+}
+
+func TestLWSReconciler_ForeignOwnedPDB_NotAdopted(t *testing.T) {
+	ctx := context.Background()
+
+	lws := newTestLWS("vllm", "default", 4, 8, map[string]string{
+		AnnotationAvailabilityClass: "mission-critical",
+	}, nil)
+	lws.SetFinalizers([]string{FinalizerPDBCleanup})
+
+	minAvailable := intstr.FromString("90%")
+	controller := true
+	foreignPDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vllm-pdb",
+			Namespace: "default",
+			Labels:    map[string]string{LabelManagedBy: OperatorName},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "StatefulSet",
+				Name:       "vllm",
+				UID:        "sts-uid",
+				Controller: &controller,
+			}},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{MinAvailable: &minAvailable},
+	}
+
+	tr := CreateTestReconcilers(lws, foreignPDB)
+	reconciler := newLWSTestReconciler(tr)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "vllm", Namespace: "default"},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultRequeueDelay, result.RequeueAfter, "should wait for the other controller to release the PDB")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, tr.Client.Get(ctx, types.NamespacedName{Name: "vllm-pdb", Namespace: "default"}, pdb))
+	assert.Equal(t, "90%", pdb.Spec.MinAvailable.String(), "foreign PDB spec must not be touched")
+	assert.Equal(t, "StatefulSet", pdb.OwnerReferences[0].Kind, "foreign PDB ownership must not be touched")
+}
+
+func TestStatefulSetReconciler_SkipsLWSInternal(t *testing.T) {
+	ctx := context.Background()
+
+	sts := newTestStatefulSet("vllm-sim-0", "default", 7, map[string]string{
+		AnnotationAvailabilityClass: "mission-critical",
+	}, map[string]string{
+		LWSSetNameLabelKey: "vllm-sim",
+		"tier":             "inference",
+	})
+	sts.Finalizers = []string{FinalizerPDBCleanup}
+
+	minAvailable := intstr.FromString("90%")
+	controller := true
+	stalePDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vllm-sim-0-pdb",
+			Namespace: "default",
+			Labels:    map[string]string{LabelManagedBy: OperatorName},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "StatefulSet",
+				Name:       "vllm-sim-0",
+				UID:        "sts-uid",
+				Controller: &controller,
+			}},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{MinAvailable: &minAvailable},
+	}
+
+	tr := CreateTestReconcilers(sts, stalePDB)
+	reconciler := tr.StatefulSetReconciler
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "vllm-sim-0", Namespace: "default"},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = tr.Client.Get(ctx, types.NamespacedName{Name: "vllm-sim-0-pdb", Namespace: "default"}, pdb)
+	assert.True(t, errors.IsNotFound(err), "stale pod-level PDB must be cleaned up")
+
+	updatedSts := &appsv1.StatefulSet{}
+	require.NoError(t, tr.Client.Get(ctx, req.NamespacedName, updatedSts))
+	assert.NotContains(t, updatedSts.Finalizers, FinalizerPDBCleanup, "finalizer must be released")
+}
+
+func TestLWSReconciler_Deletion_CleansUp(t *testing.T) {
+	ctx := context.Background()
+
+	lws := newTestLWS("gone", "default", 4, 8, map[string]string{
+		AnnotationAvailabilityClass: "standard",
+	}, nil)
+
+	tr := CreateTestReconcilers(lws)
+	reconciler := newLWSTestReconciler(tr)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"},
+	}
+
+	// reconcile twice: finalizer then PDB
+	_, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, tr.Client.Get(ctx, types.NamespacedName{Name: "gone-pdb", Namespace: "default"}, pdb))
+
+	// delete: finalizer keeps the object; reconcile must remove PDB and finalizer
+	current := NewLWSObject()
+	require.NoError(t, tr.Client.Get(ctx, req.NamespacedName, current))
+	require.NoError(t, tr.Client.Delete(ctx, current))
+
+	_, err = reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+
+	err = tr.Client.Get(ctx, types.NamespacedName{Name: "gone-pdb", Namespace: "default"}, pdb)
+	assert.True(t, errors.IsNotFound(err), "PDB should be deleted with its owner")
+
+	err = tr.Client.Get(ctx, req.NamespacedName, NewLWSObject())
+	assert.True(t, errors.IsNotFound(err), "LWS should be gone once the finalizer is removed")
+}

--- a/internal/controller/statefulset_controller.go
+++ b/internal/controller/statefulset_controller.go
@@ -143,6 +143,28 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
+	// LWS-internal StatefulSets (leader + per-group workers) are disruption-managed at the LeaderWorkerSet level
+	if _, partOfLWS := sts.Labels[LWSSetNameLabelKey]; partOfLWS {
+		logger.Info("StatefulSet belongs to a LeaderWorkerSet, skipping PDB management", map[string]any{})
+		tracing.AddEvent(ctx, "SkippedPDB", attribute.String("reason", "leaderworkerset_managed"))
+		r.tracker.ClearState(w)
+		if err := CleanupPDB(ctx, r.Client, r.Events, w, logger.ToLogr()); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to clean up PDB for LWS-managed StatefulSet", map[string]any{})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+		}
+		if controllerutil.ContainsFinalizer(sts, FinalizerPDBCleanup) {
+			patch := client.MergeFrom(sts.DeepCopy())
+			controllerutil.RemoveFinalizer(sts, FinalizerPDBCleanup)
+			if err := r.Patch(ctx, sts, patch); err != nil {
+				reconcileErr = err
+				logger.Error(err, "Failed to remove finalizer from LWS-managed StatefulSet", map[string]any{})
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if w.GetReplicas() < 2 {
 		logger.Info("Single replica, no PDB required", map[string]any{"replicas": w.GetReplicas()})
 		tracing.AddEvent(ctx, "SkippedPDB",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -87,6 +87,14 @@ var (
 		[]string{"namespace", "availability_class"},
 	)
 
+	ManagedLeaderWorkerSets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "pdb_operator_leaderworkersets_managed",
+			Help: "Current number of leaderworkersets being managed",
+		},
+		[]string{"namespace", "availability_class"},
+	)
+
 	PDBComplianceStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "pdb_operator_compliance_status",
@@ -243,6 +251,7 @@ func init() {
 		ReconciliationErrors,
 		ManagedDeployments,
 		ManagedStatefulSets,
+		ManagedLeaderWorkerSets,
 		PDBComplianceStatus,
 		AvailabilityPoliciesActive,
 		MaintenanceWindowActive,


### PR DESCRIPTION
Closes #81.

## What

Group-aware PDB management for [LeaderWorkerSet](https://lws.sigs.k8s.io/) (`leaderworkerset.x-k8s.io/v1`), the de-facto API for multi-host inference (vLLM/SGLang). LWS groups restart as a unit (default `RecreateGroupOnPodRestart`), so a pod-counting PDB both permits the capacity loss it exists to prevent and then wedges node drains. The operator now quantizes the budget to whole groups:

```
desiredGroups = ceil(class% x replicas), clamped to replicas - 1
minAvailable  = desiredGroups x size
```

| Shape | Behavior |
| --- | --- |
| `replicas: 4, size: 8`, mission-critical | `minAvailable: 24`, exactly one group disruptable |
| `replicas: 1` | No PDB + Warning event (any budget permanently blocks drains) |
| `size: 1` | Plain pod-level semantics |
| custom absolute `minAvailable` | Rounded up to whole groups |

Support is detected at startup via discovery; without the LWS CRD the operator runs unchanged (no informer, no RBAC use). The LWS type is handled as unstructured, no new module dependency.

## Design change found during verification

Issue #81 did not anticipate this: LWS implements each set as a **leader StatefulSet plus per-group worker StatefulSets**, all inheriting the workload's labels. The existing StatefulSet controller matched the policy on all of them and created 5 pod-level PDBs (verified in kind). Overlapping PDBs are worse than the deadlock: the eviction API rejects **every** eviction for a pod matched by more than one PDB.

Fixes included:
- StatefulSet controller skips any StatefulSet carrying `leaderworkerset.sigs.k8s.io/name` and cleans up PDBs + finalizers it previously created for them
- LWS reconciler never adopts a PDB owned by another kind; it requeues until the owning controller releases the name

## Verification (kind, 3 nodes, LWS v0.10.0, `replicas: 4, size: 8` = 32 pods, 40s simulated model load)

**Deadlock repro with the naive pod-level `90%` budget** (what pod semantics produce):

1. `disruptionsAllowed: 3` at steady state; evicting **one** pod was allowed
2. LWS gang-restarted the group: `currentHealthy: 24, desiredHealthy: 29, disruptionsAllowed: 0`, reason `InsufficientPods`, 25% capacity gone
3. Evicting another pod of the *same doomed group* (the rest of that node's drain): `429 TooManyRequests`, the drain can never finish
4. Evicting from any other group: `429`, all drains wedged

**With this PR** (operator-created `minAvailable: 24`, owner `LeaderWorkerSet/vllm-sim`):

1. `currentHealthy: 32, desiredHealthy: 24, disruptionsAllowed: 8`, exactly one group
2. A drain-style pass evicted **all 8 pods of one group** successfully
3. A 9th eviction from another group was rejected while the group reloaded, capacity floor held at 24
4. After recovery, `disruptionsAllowed: 8` again and the next group's eviction succeeded, drains progress group-by-group

Also verified live: on rollout the operator deleted its 5 wrong pod-level PDBs and converged to the single LWS-owned one, and it starts cleanly on clusters without the LWS CRD (`LeaderWorkerSet CRD not found - group-aware PDB support disabled`).

## Tests

- `TestQuantizeMinAvailableForGroups`: 10 table cases (exact multiples, clamping, absolute values, `size: 1`, single group, invalid input)
- `TestLWSReconciler_PolicyBasedPDB_Quantized`, `_SingleGroup_NoPDB`, `_SizeOne_PodLevel`, `_Deletion_CleansUp`, `_ForeignOwnedPDB_NotAdopted`
- `TestStatefulSetReconciler_SkipsLWSInternal`
- `make test` and `make lint` green; RBAC regenerated via `make manifests` (two new rule blocks only)

## Not included (follow-up)

An automated e2e that installs LWS in the CI kind cluster. The scenario above was scripted and run manually; wiring LWS install into `test-e2e` is a separate change if wanted.
