### PR TITLE
fix(metrics): recount StatefulSets and LeaderWorkerSets in the periodic updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `pdb_operator_statefulsets_managed` and `pdb_operator_leaderworkersets_managed` now report real counts: the periodic metrics updater only recounted Deployments, so both gauges acted as sticky "seen once" flags and never dropped on deletion. The updater now recounts all three kinds each tick, excludes LWS-internal StatefulSets, and skips the LeaderWorkerSet list entirely when the CRD is absent (#85)
+
 ## [0.4.0] - 2026-08-15
 
 ### Added

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -343,7 +344,8 @@ func main() {
 		os.Exit(1)
 	}
 	// Register LeaderWorkerSet controller only when the CRD is installed
-	if checkLeaderWorkerSetAvailable(mgr.GetConfig()) {
+	lwsEnabled := checkLeaderWorkerSetAvailable(mgr.GetConfig())
+	if lwsEnabled {
 		if err := (&pdbcontroller.LeaderWorkerSetReconciler{
 			Client:      circuitBreakerClient,
 			Scheme:      mgr.GetScheme(),
@@ -471,7 +473,7 @@ func main() {
 	case synced := <-cacheSynced:
 		if synced {
 			setupLog.Info("Cache synced, starting metrics updater")
-			go startMetricsUpdater(bgCtx, circuitBreakerClient, policyCache)
+			go startMetricsUpdater(bgCtx, circuitBreakerClient, policyCache, lwsEnabled)
 		} else {
 			setupLog.Error(nil, "Failed to sync cache, metrics updater will not start")
 		}
@@ -532,7 +534,7 @@ func (gsm *GracefulShutdownManager) runPreShutdownHooks(ctx context.Context) {
 }
 
 // startMetricsUpdater periodically updates global metrics
-func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache) {
+func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache, lwsEnabled bool) {
 	select {
 	case <-time.After(5 * time.Second):
 	case <-ctx.Done():
@@ -550,7 +552,7 @@ func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.
 		}()
 
 		if c != nil {
-			updateGlobalMetrics(ctx, c)
+			updateGlobalMetrics(ctx, c, lwsEnabled)
 		}
 		if pCache != nil {
 			metrics.UpdateCacheMetrics(pCache.GetStats())
@@ -570,7 +572,20 @@ func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.
 	}
 }
 
-func updateGlobalMetrics(ctx context.Context, c client.Client) {
+// countByClass accumulates a namespace/class count from an availability-class annotation.
+func countByClass(counts map[string]map[string]int, namespace string, annotations map[string]string) bool {
+	class, exists := annotations[pdbcontroller.AnnotationAvailabilityClass]
+	if !exists {
+		return false
+	}
+	if counts[namespace] == nil {
+		counts[namespace] = make(map[string]int)
+	}
+	counts[namespace][class]++
+	return true
+}
+
+func updateGlobalMetrics(ctx context.Context, c client.Client, lwsEnabled bool) {
 	ctx = logging.WithCorrelationID(ctx)
 	ctx = logging.WithOperation(ctx, "metrics-update")
 
@@ -586,19 +601,49 @@ func updateGlobalMetrics(ctx context.Context, c client.Client) {
 	managedCount := 0
 
 	for _, deployment := range deploymentList.Items {
-		if deployment.Annotations != nil {
-			if class, exists := deployment.Annotations[pdbcontroller.AnnotationAvailabilityClass]; exists {
-				namespace := deployment.Namespace
-				if deploymentCounts[namespace] == nil {
-					deploymentCounts[namespace] = make(map[string]int)
-				}
-				deploymentCounts[namespace][class]++
-				managedCount++
-			}
+		if countByClass(deploymentCounts, deployment.Namespace, deployment.Annotations) {
+			managedCount++
 		}
 	}
 
 	metrics.UpdateManagedDeployments(deploymentCounts)
+
+	statefulSetList := &appsv1.StatefulSetList{}
+	if err := c.List(ctx, statefulSetList); err != nil {
+		logger.Error(err, "Failed to list statefulsets for metrics")
+		return
+	}
+
+	statefulSetCounts := make(map[string]map[string]int)
+	for _, sts := range statefulSetList.Items {
+		// LWS-internal StatefulSets are disruption-managed at the LeaderWorkerSet level
+		if _, partOfLWS := sts.Labels[pdbcontroller.LWSSetNameLabelKey]; partOfLWS {
+			continue
+		}
+		if countByClass(statefulSetCounts, sts.Namespace, sts.Annotations) {
+			managedCount++
+		}
+	}
+
+	metrics.UpdateManagedStatefulSets(statefulSetCounts)
+
+	if lwsEnabled {
+		lwsList := &unstructured.UnstructuredList{}
+		lwsList.SetGroupVersionKind(pdbcontroller.LWSGVK.GroupVersion().WithKind(pdbcontroller.LWSGVK.Kind + "List"))
+		if err := c.List(ctx, lwsList); err != nil {
+			logger.Error(err, "Failed to list leaderworkersets for metrics")
+			return
+		}
+
+		lwsCounts := make(map[string]map[string]int)
+		for i := range lwsList.Items {
+			if countByClass(lwsCounts, lwsList.Items[i].GetNamespace(), lwsList.Items[i].GetAnnotations()) {
+				managedCount++
+			}
+		}
+
+		metrics.UpdateManagedLeaderWorkerSets(lwsCounts)
+	}
 
 	policyList := &availabilityv1alpha1.PDBPolicyList{}
 	if err := c.List(ctx, policyList); err != nil {
@@ -614,7 +659,7 @@ func updateGlobalMetrics(ctx context.Context, c client.Client) {
 	metrics.UpdateActivePoliciesCount(policyCounts)
 
 	logger.V(1).Info("Updated global metrics",
-		"managedDeployments", managedCount,
+		"managedWorkloads", managedCount,
 		"activePolicies", len(policyList.Items))
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -317,6 +317,15 @@ func UpdateManagedStatefulSets(counts map[string]map[string]int) {
 	}
 }
 
+func UpdateManagedLeaderWorkerSets(counts map[string]map[string]int) {
+	ManagedLeaderWorkerSets.Reset()
+	for namespace, classCounts := range counts {
+		for class, count := range classCounts {
+			ManagedLeaderWorkerSets.WithLabelValues(namespace, class).Set(float64(count))
+		}
+	}
+}
+
 func UpdateComplianceStatus(namespace, deployment string, compliant bool, reason string) {
 	value := 0.0
 	if compliant {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -94,6 +94,34 @@ func TestUpdateManagedDeployments(t *testing.T) {
 	assert.Equal(t, 3, count, "Should have 3 gauge entries")
 }
 
+func TestUpdateManagedStatefulSets(t *testing.T) {
+	UpdateManagedStatefulSets(map[string]map[string]int{
+		"default": {"standard": 2},
+	})
+	count := testutil.CollectAndCount(ManagedStatefulSets, "pdb_operator_statefulsets_managed")
+	assert.Equal(t, 1, count, "Should have 1 gauge entry")
+
+	// recount must reset stale series, not accumulate them
+	UpdateManagedStatefulSets(map[string]map[string]int{
+		"production": {"mission-critical": 1},
+	})
+	count = testutil.CollectAndCount(ManagedStatefulSets, "pdb_operator_statefulsets_managed")
+	assert.Equal(t, 1, count, "Stale series should be reset on recount")
+}
+
+func TestUpdateManagedLeaderWorkerSets(t *testing.T) {
+	UpdateManagedLeaderWorkerSets(map[string]map[string]int{
+		"default":   {"mission-critical": 4},
+		"inference": {"high-availability": 1},
+	})
+	count := testutil.CollectAndCount(ManagedLeaderWorkerSets, "pdb_operator_leaderworkersets_managed")
+	assert.Equal(t, 2, count, "Should have 2 gauge entries")
+
+	UpdateManagedLeaderWorkerSets(map[string]map[string]int{})
+	count = testutil.CollectAndCount(ManagedLeaderWorkerSets, "pdb_operator_leaderworkersets_managed")
+	assert.Equal(t, 0, count, "Empty recount should zero the gauge")
+}
+
 func TestUpdateComplianceStatus(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Closes #85.

`updateGlobalMetrics` (the 30s ticker) listed only Deployments, so `pdb_operator_statefulsets_managed` and `pdb_operator_leaderworkersets_managed` were only ever touched by the reconcilers' `.Set(1)`: sticky "seen once" flags that never dropped on deletion or class change. `UpdateManagedStatefulSets` existed with zero callers; `UpdateManagedLeaderWorkerSets` did not exist.

## Changes

- `cmd/main.go`: recount all three kinds each tick, via a shared `countByClass` helper (same annotation-based semantics as the existing Deployment logic). LWS-internal StatefulSets (label `leaderworkerset.sigs.k8s.io/name`) are excluded, consistent with the controller skip from #82.
- The LeaderWorkerSet list is gated on the startup CRD detection (`checkLeaderWorkerSetAvailable`), so on clusters without the CRD the cached client never starts an informer for it and the log stays clean, no per-tick `NoKindMatchError` handling needed.
- `internal/metrics/metrics.go`: add the missing `UpdateManagedLeaderWorkerSets` (Reset + recount).
- Tests for `UpdateManagedStatefulSets` (stale-series reset) and `UpdateManagedLeaderWorkerSets` (recount + empty-map zeroing).

## Known limitation (pre-existing, unchanged)

Counting is annotation-based; workloads managed purely via policy matching are not counted by these gauges. Noted in #85, out of scope here.

## Verification

- `make test` green (metrics package now 61.5% coverage, was 52.5%)
- `make lint`: 0 issues
