### PR TITLE
ci: exclude cloud-native.slack.com from link checking

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
-          args: --verbose --no-progress --max-retries 5 --retry-wait-time 2 --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' '**/*.md'
+          args: --verbose --no-progress --max-retries 5 --retry-wait-time 2 --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' --exclude 'cloud-native\.slack\.com' '**/*.md'
           fail: true


### PR DESCRIPTION
Closes #87.

The CNCF Slack links in the README intermittently 403 for lychee (Slack blocks anonymous/bot requests after redirects), e.g. [this run](https://github.com/pdb-operator/pdb-operator/actions/runs/31869451157/job/94975692688) on #86, minutes after passing on #84. Retries cannot fix an active bot block, so exclude the domain.

One-line change to the lychee args. helm-pdb-operator and pdboperator.io may need the same exclude if their READMEs link the Slack channel.