### PR TITLE
docs(changelog): add 0.4.1 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-15
+
 ### Fixed
 - `pdb_operator_statefulsets_managed` and `pdb_operator_leaderworkersets_managed` now report real counts: the periodic metrics updater only recounted Deployments, so both gauges acted as sticky "seen once" flags and never dropped on deletion. The updater now recounts all three kinds each tick, excludes LWS-internal StatefulSets, and skips the LeaderWorkerSet list entirely when the CRD is absent (#85)
 


### PR DESCRIPTION
Release prep for v0.4.1. Moves the `[Unreleased]` entry into a dated `## [0.4.1]` section:

- Managed-workload gauges fix: recount StatefulSets and LeaderWorkerSets in the periodic metrics updater (#85, #86)

Also on main since v0.4.0 but not user-facing: the check-links Slack exclude (#87, #88).

Tag `v0.4.1` follows once this merges.