### PR TITLE
ci: exclude lws.sigs.k8s.io from link checking

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
-          args: --verbose --no-progress --max-retries 5 --retry-wait-time 2 --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' --exclude 'cloud-native\.slack\.com' '**/*.md'
+          args: --verbose --no-progress --max-retries 5 --retry-wait-time 2 --exclude localhost --exclude 'github\.com/.*/compare/' --exclude 'github\.com/.*/releases/tag/' --exclude 'cloud-native\.slack\.com' --exclude 'lws\.sigs\.k8s\.io' '**/*.md'
           fail: true


### PR DESCRIPTION
Closes #87 (reopened).

Second domain in the bot-blocking class: `https://lws.sigs.k8s.io/` (README, added in #82) fails with `Connection reset by peer` after all 5 lychee retries ([run on #89](https://github.com/pdb-operator/pdb-operator/actions/runs/31870374863/job/94977976303)), while loading fine in a browser. Same one-line fix as #88.

If a third domain shows up, the next step should be moving excludes to a `.lycheeignore` file and/or making check-links non-blocking for release PRs.