### PR TITLE
test(e2e): automate the LWS gang-disruption scenario from #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Testing
+- The kind e2e suite now covers the LWS gang-disruption scenario from #81: LeaderWorkerSet v0.10.0 is installed into the test cluster, a 4x2 fixture under a `mission-critical` policy asserts the group-quantized `minAvailable: 6`, group-granular eviction gating (one group evictable, a second rejected until the first reloads), the LWS-internal StatefulSet skip, and the single-group no-PDB warning (#83)
+
 ## [0.4.1] - 2026-08-15
 
 ### Fixed

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -33,9 +33,14 @@ var (
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
 	// These variables are useful if CertManager is already installed, avoiding
 	// re-installation and conflicts.
+	// - LWS_INSTALL_SKIP=true: Skips LeaderWorkerSet installation during test setup.
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
+
+	skipLWSInstall = os.Getenv("LWS_INSTALL_SKIP") == "true"
+	// isLWSAlreadyInstalled will be set true when the LeaderWorkerSet CRD is found on the cluster
+	isLWSAlreadyInstalled = false
 
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
@@ -78,6 +83,18 @@ var _ = BeforeSuite(func() {
 			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: CertManager is already installed. Skipping installation...\n")
 		}
 	}
+
+	// LWS must exist before the manager deploys: LWS support is detected at startup
+	if !skipLWSInstall {
+		By("checking if LeaderWorkerSet is installed already")
+		isLWSAlreadyInstalled = utils.IsLWSCRDsInstalled()
+		if !isLWSAlreadyInstalled {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Installing LeaderWorkerSet...\n")
+			Expect(utils.InstallLWS()).To(Succeed(), "Failed to install LeaderWorkerSet")
+		} else {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: LeaderWorkerSet is already installed. Skipping installation...\n")
+		}
+	}
 })
 
 var _ = AfterSuite(func() {
@@ -85,5 +102,11 @@ var _ = AfterSuite(func() {
 	if !skipCertManagerInstall && !isCertManagerAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")
 		utils.UninstallCertManager()
+	}
+
+	// Teardown LWS after the suite if not skipped and if it was not already installed
+	if !skipLWSInstall && !isLWSAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling LeaderWorkerSet...\n")
+		utils.UninstallLWS()
 	}
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -99,6 +99,11 @@ var _ = Describe("Manager", Ordered, func() {
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
 		_, _ = utils.Run(cmd)
 
+		By("deleting LeaderWorkerSets while the operator can still process their finalizers")
+		cmd = exec.Command("kubectl", "delete", "leaderworkersets", "--all", "-n", "default",
+			"--ignore-not-found", "--timeout=60s")
+		_, _ = utils.Run(cmd)
+
 		By("undeploying the controller-manager")
 		cmd = exec.Command("make", "undeploy")
 		_, _ = utils.Run(cmd)
@@ -728,6 +733,279 @@ spec:
 			cleanupDeployment(deployName)
 			DeferCleanup(func() { cleanupDeployment(deployName) })
 			verifyScaleDownCleansUpPDB("Deployment", "deployment", deployName, testNamespace)
+		})
+	})
+
+	Context("LeaderWorkerSet PDB management", func() {
+		const testNamespace = "default"
+		const lwsNameLabel = "leaderworkerset.sigs.k8s.io/name"
+		const lwsGroupLabel = "leaderworkerset.sigs.k8s.io/group-index"
+
+		// dedent strips leading tabs from YAML heredocs so kubectl can parse them.
+		dedent := func(s string) string {
+			return strings.ReplaceAll(s, "\t", "")
+		}
+
+		// cleanupLWS removes a LeaderWorkerSet, its PDB, and its policy; idempotent.
+		// The LWS delete blocks so the operator can process the PDB-cleanup finalizer.
+		cleanupLWS := func(name string) {
+			cmd := exec.Command("kubectl", "delete", "leaderworkerset", name, "-n", testNamespace,
+				"--ignore-not-found", "--timeout=60s")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pdb", name+"-pdb", "-n", testNamespace,
+				"--ignore-not-found", "--wait=false")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pdbpolicy", name+"-policy", "-n", testNamespace,
+				"--ignore-not-found", "--wait=false")
+			_, _ = utils.Run(cmd)
+		}
+
+		// evictPod issues a policy/v1 Eviction through the API server.
+		evictPod := func(podName string) (string, error) {
+			eviction := fmt.Sprintf(
+				`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":%q,"namespace":%q}}`,
+				podName, testNamespace)
+			cmd := exec.Command("kubectl", "create", "--raw",
+				fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/eviction", testNamespace, podName),
+				"-f", "-")
+			cmd.Stdin = strings.NewReader(eviction)
+			return utils.Run(cmd)
+		}
+
+		// readyStatuses returns the Ready condition status of every pod of the LWS.
+		readyStatuses := func(g Gomega, name string) []string {
+			cmd := exec.Command("kubectl", "get", "pods",
+				"-l", lwsNameLabel+"="+name, "-n", testNamespace,
+				"-o", "jsonpath={.items[*].status.conditions[?(@.type==\"Ready\")].status}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.Fields(output)
+		}
+
+		waitAllPodsReady := func(name string, count int) {
+			Eventually(func(g Gomega) {
+				statuses := readyStatuses(g, name)
+				g.Expect(statuses).To(HaveLen(count))
+				for _, s := range statuses {
+					g.Expect(s).To(Equal("True"))
+				}
+			}, 5*time.Minute).Should(Succeed())
+		}
+
+		disruptionsAllowed := func(g Gomega, name string) string {
+			cmd := exec.Command("kubectl", "get", "pdb", name+"-pdb", "-n", testNamespace,
+				"-o", "jsonpath={.status.disruptionsAllowed}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return output
+		}
+
+		It("should quantize the PDB to whole groups and gate evictions at group granularity", func() {
+			const lwsName = "e2e-lws-gang"
+			cleanupLWS(lwsName)
+			DeferCleanup(func() { cleanupLWS(lwsName) })
+
+			By("creating a mission-critical PDBPolicy selecting the LeaderWorkerSet")
+			policyYAML := fmt.Sprintf(`
+apiVersion: availability.pdboperator.io/v1alpha1
+kind: PDBPolicy
+metadata:
+  name: %s-policy
+  namespace: %s
+spec:
+  availabilityClass: mission-critical
+  enforcement: strict
+  workloadSelector:
+    matchLabels:
+      app: %s
+  priority: 100
+`, lwsName, testNamespace, lwsName)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(dedent(policyYAML))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create PDBPolicy")
+
+			By("creating a LeaderWorkerSet with 4 groups of size 2 and slow-ready pods")
+			// sleep-then-touch readiness simulates model load so group recovery is observable
+			lwsYAML := fmt.Sprintf(`
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: %s
+spec:
+  replicas: 4
+  leaderWorkerTemplate:
+    size: 2
+    restartPolicy: RecreateGroupOnPodRestart
+    workerTemplate:
+      metadata:
+        labels:
+          app: %s
+      spec:
+        terminationGracePeriodSeconds: 3
+        containers:
+        - name: model
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 15; touch /tmp/ready; sleep infinity"]
+          readinessProbe:
+            exec:
+              command: ["cat", "/tmp/ready"]
+            periodSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+`, lwsName, testNamespace, lwsName, lwsName)
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(dedent(lwsYAML))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create LeaderWorkerSet")
+
+			By("waiting for the group-quantized PDB")
+			// mission-critical (90%) over 4 groups: ceil(0.9*4)=4, clamped to 3 groups x 2 pods = 6
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pdb", lwsName+"-pdb", "-n", testNamespace,
+					"-o", "jsonpath={.spec.minAvailable}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "PDB should exist")
+				g.Expect(output).To(Equal("6"), "minAvailable should be quantized to 3 groups x 2 pods")
+			}).Should(Succeed())
+
+			By("verifying the PDB selects pods by the LWS name label")
+			cmd = exec.Command("kubectl", "get", "pdb", lwsName+"-pdb", "-n", testNamespace,
+				"-o", "jsonpath={.spec.selector.matchLabels['leaderworkerset\\.sigs\\.k8s\\.io/name']}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(Equal(lwsName))
+
+			By("verifying the StatefulSet controller created no PDBs for LWS-internal StatefulSets")
+			// the leader StatefulSet shares the LWS name, so an unskipped STS would overwrite this PDB
+			Consistently(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pdb", "-n", testNamespace, "-o", "name")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				var lwsPDBs []string
+				for _, line := range utils.GetNonEmptyLines(output) {
+					if strings.Contains(line, lwsName) {
+						lwsPDBs = append(lwsPDBs, line)
+					}
+				}
+				g.Expect(lwsPDBs).To(ConsistOf("poddisruptionbudget.policy/" + lwsName + "-pdb"))
+
+				cmd = exec.Command("kubectl", "get", "pdb", lwsName+"-pdb", "-n", testNamespace,
+					"-o", "jsonpath={.metadata.ownerReferences[0].kind} {.spec.minAvailable}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("LeaderWorkerSet 6"))
+			}, 15*time.Second, 3*time.Second).Should(Succeed())
+
+			By("waiting for all 8 pods to become Ready")
+			waitAllPodsReady(lwsName, 8)
+
+			By("waiting for the PDB to allow exactly one group of disruptions")
+			Eventually(func(g Gomega) {
+				g.Expect(disruptionsAllowed(g, lwsName)).To(Equal("2"))
+			}).Should(Succeed())
+
+			By("evicting every pod of group 0 in one pass")
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-l", lwsNameLabel+"="+lwsName+","+lwsGroupLabel+"=0",
+				"-n", testNamespace, "-o", "jsonpath={.items[*].metadata.name}")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			groupZeroPods := strings.Fields(output)
+			Expect(groupZeroPods).To(HaveLen(2), "group 0 should have leader + 1 worker")
+			for _, pod := range groupZeroPods {
+				_, err := evictPod(pod)
+				Expect(err).NotTo(HaveOccurred(), "eviction of %s should be admitted", pod)
+			}
+
+			By("waiting for the budget to be exhausted while group 0 reloads")
+			Eventually(func(g Gomega) {
+				g.Expect(disruptionsAllowed(g, lwsName)).To(Equal("0"))
+			}, 30*time.Second).Should(Succeed())
+
+			By("asserting an eviction from another group is rejected while group 0 reloads")
+			cmd = exec.Command("kubectl", "get", "pods",
+				"-l", lwsNameLabel+"="+lwsName+","+lwsGroupLabel+"=1",
+				"-n", testNamespace, "-o", "jsonpath={.items[0].metadata.name}")
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			groupOnePod := strings.TrimSpace(output)
+			Expect(groupOnePod).NotTo(BeEmpty())
+			evictOutput, err := evictPod(groupOnePod)
+			Expect(err).To(HaveOccurred(), "eviction should be rejected while the budget is exhausted")
+			Expect(evictOutput).To(ContainSubstring("disruption budget"))
+
+			By("waiting for group 0 to reload and the budget to recover")
+			waitAllPodsReady(lwsName, 8)
+			Eventually(func(g Gomega) {
+				g.Expect(disruptionsAllowed(g, lwsName)).To(Equal("2"))
+			}).Should(Succeed())
+
+			By("evicting the group-1 pod now that the budget has recovered")
+			_, err = evictPod(groupOnePod)
+			Expect(err).NotTo(HaveOccurred(), "eviction should succeed after recovery")
+		})
+
+		It("should skip PDB creation for a single-group LeaderWorkerSet and emit a warning", func() {
+			const lwsName = "e2e-lws-single"
+			cleanupLWS(lwsName)
+			DeferCleanup(func() { cleanupLWS(lwsName) })
+
+			By("creating a single-group LeaderWorkerSet")
+			lwsYAML := fmt.Sprintf(`
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: %s
+  namespace: %s
+  annotations:
+    pdboperator.io/availability-class: high-availability
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 2
+    workerTemplate:
+      spec:
+        terminationGracePeriodSeconds: 3
+        containers:
+        - name: app
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+`, lwsName, testNamespace)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(dedent(lwsYAML))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create single-group LeaderWorkerSet")
+
+			By("waiting for the LeaderWorkerSetSkipped warning event")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "events", "-n", testNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				found := false
+				for _, line := range utils.GetNonEmptyLines(output) {
+					if strings.Contains(line, "LeaderWorkerSetSkipped") && strings.Contains(line, lwsName) {
+						found = true
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected a LeaderWorkerSetSkipped event for %s", lwsName)
+			}).Should(Succeed())
+
+			By("confirming no PDB is created for the single group")
+			Consistently(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pdb", lwsName+"-pdb", "-n", testNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "PDB should not exist for a single-group LeaderWorkerSet")
+			}, 15*time.Second, 3*time.Second).Should(Succeed())
 		})
 	})
 })

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -35,6 +35,9 @@ const (
 
 	certmanagerVersion = "v1.16.3"
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
+
+	lwsVersion = "v0.10.0"
+	lwsURLTmpl = "https://github.com/kubernetes-sigs/lws/releases/download/%s/manifests.yaml"
 )
 
 func warnError(err error) {
@@ -146,6 +149,39 @@ func InstallCertManager() error {
 		time.Sleep(5 * time.Second)
 	}
 	return fmt.Errorf("timed out waiting for cert-manager CA bundle to be injected")
+}
+
+// InstallLWS installs the LeaderWorkerSet operator and waits for its controller.
+func InstallLWS() error {
+	url := fmt.Sprintf(lwsURLTmpl, lwsVersion)
+	// server-side apply: the LWS CRD schema exceeds the client-side annotation limit
+	cmd := exec.Command("kubectl", "apply", "--server-side", "-f", url)
+	if _, err := Run(cmd); err != nil {
+		return err
+	}
+	cmd = exec.Command("kubectl", "wait", "deployment.apps/lws-controller-manager",
+		"--for", "condition=Available",
+		"--namespace", "lws-system",
+		"--timeout", "5m",
+	)
+	_, err := Run(cmd)
+	return err
+}
+
+// UninstallLWS uninstalls the LeaderWorkerSet operator bundle.
+func UninstallLWS() {
+	url := fmt.Sprintf(lwsURLTmpl, lwsVersion)
+	cmd := exec.Command("kubectl", "delete", "-f", url)
+	if _, err := Run(cmd); err != nil {
+		warnError(err)
+	}
+}
+
+// IsLWSCRDsInstalled checks if the LeaderWorkerSet CRD is present.
+func IsLWSCRDsInstalled() bool {
+	cmd := exec.Command("kubectl", "get", "crd", "leaderworkersets.leaderworkerset.x-k8s.io")
+	_, err := Run(cmd)
+	return err == nil
 }
 
 // IsCertManagerCRDsInstalled checks if any Cert Manager CRDs are installed


### PR DESCRIPTION
## Summary

Closes #83. The gang-disruption behavior shipped in #82 was only verified with scripted manual runs; this wires the scenario into the automated kind e2e suite.

## What the suite now covers

- **LWS install**: LeaderWorkerSet v0.10.0 manifests are applied (server-side, the CRD schema exceeds the client-side annotation limit) in `BeforeSuite`, before the operator deploys, since LWS support is detected at manager startup. Skippable via `LWS_INSTALL_SKIP=true`, mirroring the cert-manager toggle.
- **Group quantization**: a `replicas: 4, size: 2` fixture with slow-ready pods (sleep-then-touch readiness simulating model load) under a strict `mission-critical` policy gets `minAvailable: 6` (`ceil(0.9 x 4) = 4`, clamped to 3 groups x 2 pods), owned by the LeaderWorkerSet and selecting on `leaderworkerset.sigs.k8s.io/name`.
- **StatefulSet skip**: a `Consistently` window asserts the only PDB for the fixture is the LWS-owned one; the leader StatefulSet shares the LWS name, so an unskipped StatefulSet would overwrite it (caught via ownerRef + minAvailable).
- **Group-granular eviction gating**: both pods of group 0 are evicted through the eviction API in one pass (admitted), an eviction from group 1 is rejected with the disruption-budget error while group 0 reloads, and admitted once all 8 pods are Ready again.
- **Single group**: a `replicas: 1` fixture gets no PDB plus the `LeaderWorkerSetSkipped` warning event.

Suite cleanup deletes LeaderWorkerSets before the operator undeploys so their PDB-cleanup finalizers can be processed, and uninstalls LWS in `AfterSuite` if the suite installed it.

## Verification

Full local run: `make test-e2e` on kind, 11/11 specs passed in 572s. The two new specs take ~57s and ~17s; LWS install adds ~1 min to suite setup, as anticipated in #83.