### PR TITLE
feat: gang-aware PDBs from the upstream Workload API (scheduling.k8s.io/v1beta1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Gang-aware PDBs from the upstream Workload API (`scheduling.k8s.io/v1beta1`, KEP-4671, beta in Kubernetes 1.37 behind the `GenericWorkload` gate). `disruptionMode: all` templates get budgets quantized to whole pod groups (reusing the LWS math); `single` gangs keep pod semantics floored at the gang `minCount`; shapes whose budget would permanently block drains (single all-mode group, `minCount` covering every pod) get no PDB plus a Warning event. The PDB selector is derived from labels common to the group's pods and validated for exactness, since pods reference their PodGroup through `spec.schedulingGroup.podGroupName` rather than a label. Support activates only when the API is served (#95)
+
 ### Testing
 - The kind e2e suite now covers the LWS gang-disruption scenario from #81: LeaderWorkerSet v0.10.0 is installed into the test cluster, a 4x2 fixture under a `mission-critical` policy asserts the group-quantized `minAvailable: 6`, group-granular eviction gating (one group evictable, a second rejected until the first reloads), the LWS-internal StatefulSet skip, and the single-group no-PDB warning (#83)
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Special cases:
 
 The PDB selects on the `leaderworkerset.sigs.k8s.io/name` label, covering leader and worker pods. LWS implements each set as a leader StatefulSet plus per-group worker StatefulSets; the operator's StatefulSet controller skips those (same label) so pods never match more than one PDB, which would make the eviction API reject every eviction.
 
+## Gang-Aware PDBs from the Workload API (Kubernetes 1.35+)
+
+When the cluster serves the upstream Workload API (`scheduling.k8s.io/v1beta1`, [KEP-4671](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4671-gang-scheduling/README.md), beta in Kubernetes 1.37 behind the `GenericWorkload` feature gate), the operator also manages PDBs for gang-scheduled workloads declared through it. Support is detected at startup; without the API the operator runs unchanged. Upstream gang scheduling is placement-only, and `disruptionMode` is consumed only by scheduler preemption, so voluntary evictions (node drains) are otherwise unprotected.
+
+| Declared shape | PDB behavior |
+|----------------|--------------|
+| `gang` policy with `disruptionMode: {all: {}}` | The group restarts as a unit, so the budget is quantized to whole pod groups (same math as LeaderWorkerSet) |
+| `gang` policy with `disruptionMode: {single: {}}` (or unset) | Pod-level semantics with `minAvailable` floored at the gang `minCount` |
+| Single all-mode group, or a `minCount` that leaves no pod evictable | No PDB; a Warning event explains why (any budget would permanently block drains) |
+| Multiple gang templates or composite templates | Skipped for now, with a Warning event |
+
+Pods reference their group via `spec.schedulingGroup.podGroupName`, which is not a label, so the PDB selector is derived from the labels common to the group's pods and validated to match exactly those pods. Until pods exist, or when no exact selector can be derived, no PDB is created and a Warning explains why. Pods already covered by a native gang path (the LWS label) are left to that path.
+
+The availability class is resolved on the `Workload` object itself: `PDBPolicy` selectors match its labels, and the `pdboperator.io/*` annotations work the same as on any other workload.
+
 ## Enforcement Modes
 
 | Mode | Behavior |
@@ -242,6 +257,7 @@ spec:
 | `pdb_operator_pdbs_deleted_total` | Counter | PDBs deleted |
 | `pdb_operator_deployments_managed` | Gauge | Managed deployments per namespace/class |
 | `pdb_operator_leaderworkersets_managed` | Gauge | Managed LeaderWorkerSets per namespace/class |
+| `pdb_operator_workloads_managed` | Gauge | Managed scheduling.k8s.io Workloads per namespace/class |
 | `pdb_operator_policies_active` | Gauge | Active policies per namespace |
 | `pdb_operator_compliance_status` | Gauge | Deployment compliance status |
 | `pdb_operator_maintenance_window_active` | Gauge | Maintenance window active |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -553,7 +553,8 @@ func (gsm *GracefulShutdownManager) runPreShutdownHooks(ctx context.Context) {
 }
 
 // startMetricsUpdater periodically updates global metrics
-func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache, lwsEnabled, workloadAPIEnabled bool) {
+func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache,
+	lwsEnabled, workloadAPIEnabled bool) {
 	select {
 	case <-time.After(5 * time.Second):
 	case <-ctx.Done():

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -362,6 +362,25 @@ func main() {
 		setupLog.Info("LeaderWorkerSet CRD not found - group-aware PDB support disabled")
 	}
 
+	// Register the Workload API controller only when scheduling.k8s.io/v1beta1 serves it
+	workloadAPIEnabled := checkWorkloadAPIAvailable(mgr.GetConfig())
+	if workloadAPIEnabled {
+		if err := (&pdbcontroller.WorkloadAPIReconciler{
+			Client:      circuitBreakerClient,
+			Scheme:      mgr.GetScheme(),
+			Recorder:    mgr.GetEventRecorder("workload-controller"),
+			Events:      eventRecorder,
+			PolicyCache: policyCache,
+			Config:      sharedConfig,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Workload")
+			os.Exit(1)
+		}
+		setupLog.Info("Workload API support enabled")
+	} else {
+		setupLog.Info("Workload API (scheduling.k8s.io/v1beta1) not served - gang-aware PDB support for it disabled")
+	}
+
 	// Setup webhooks if enabled (with graceful fallback)
 	if enableWebhook {
 		certManagerAvailable := checkCertManagerAvailable(mgr.GetConfig())
@@ -473,7 +492,7 @@ func main() {
 	case synced := <-cacheSynced:
 		if synced {
 			setupLog.Info("Cache synced, starting metrics updater")
-			go startMetricsUpdater(bgCtx, circuitBreakerClient, policyCache, lwsEnabled)
+			go startMetricsUpdater(bgCtx, circuitBreakerClient, policyCache, lwsEnabled, workloadAPIEnabled)
 		} else {
 			setupLog.Error(nil, "Failed to sync cache, metrics updater will not start")
 		}
@@ -534,7 +553,7 @@ func (gsm *GracefulShutdownManager) runPreShutdownHooks(ctx context.Context) {
 }
 
 // startMetricsUpdater periodically updates global metrics
-func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache, lwsEnabled bool) {
+func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.PolicyCache, lwsEnabled, workloadAPIEnabled bool) {
 	select {
 	case <-time.After(5 * time.Second):
 	case <-ctx.Done():
@@ -552,7 +571,7 @@ func startMetricsUpdater(ctx context.Context, c client.Client, pCache *pdbcache.
 		}()
 
 		if c != nil {
-			updateGlobalMetrics(ctx, c, lwsEnabled)
+			updateGlobalMetrics(ctx, c, lwsEnabled, workloadAPIEnabled)
 		}
 		if pCache != nil {
 			metrics.UpdateCacheMetrics(pCache.GetStats())
@@ -585,7 +604,7 @@ func countByClass(counts map[string]map[string]int, namespace string, annotation
 	return true
 }
 
-func updateGlobalMetrics(ctx context.Context, c client.Client, lwsEnabled bool) {
+func updateGlobalMetrics(ctx context.Context, c client.Client, lwsEnabled, workloadAPIEnabled bool) {
 	ctx = logging.WithCorrelationID(ctx)
 	ctx = logging.WithOperation(ctx, "metrics-update")
 
@@ -643,6 +662,24 @@ func updateGlobalMetrics(ctx context.Context, c client.Client, lwsEnabled bool) 
 		}
 
 		metrics.UpdateManagedLeaderWorkerSets(lwsCounts)
+	}
+
+	if workloadAPIEnabled {
+		wList := &unstructured.UnstructuredList{}
+		wList.SetGroupVersionKind(pdbcontroller.WorkloadGVK.GroupVersion().WithKind(pdbcontroller.WorkloadGVK.Kind + "List"))
+		if err := c.List(ctx, wList); err != nil {
+			logger.Error(err, "Failed to list workloads for metrics")
+			return
+		}
+
+		workloadCounts := make(map[string]map[string]int)
+		for i := range wList.Items {
+			if countByClass(workloadCounts, wList.Items[i].GetNamespace(), wList.Items[i].GetAnnotations()) {
+				managedCount++
+			}
+		}
+
+		metrics.UpdateManagedWorkloads(workloadCounts)
 	}
 
 	policyList := &availabilityv1alpha1.PDBPolicyList{}
@@ -711,6 +748,36 @@ func checkLeaderWorkerSetAvailable(config *rest.Config) bool {
 		}
 	}
 	return false
+}
+
+// checkWorkloadAPIAvailable checks if the cluster serves the Workload API (KEP-4671).
+func checkWorkloadAPIAvailable(config *rest.Config) bool {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		setupLog.V(1).Info("workload API check: failed to create API client",
+			"error", err.Error())
+		return false
+	}
+
+	resources, err := clientset.Discovery().ServerResourcesForGroupVersion(
+		pdbcontroller.WorkloadAPIGroup + "/" + pdbcontroller.WorkloadAPIVersion)
+	if err != nil {
+		setupLog.V(1).Info("workload API check: group version not served",
+			"groupVersion", pdbcontroller.WorkloadAPIGroup+"/"+pdbcontroller.WorkloadAPIVersion,
+			"error", err.Error())
+		return false
+	}
+
+	hasWorkload, hasPodGroup := false, false
+	for _, r := range resources.APIResources {
+		switch r.Kind {
+		case "Workload":
+			hasWorkload = true
+		case "PodGroup":
+			hasPodGroup = true
+		}
+	}
+	return hasWorkload && hasPodGroup
 }
 
 // checkCertManagerAvailable checks if cert-manager has provisioned the webhook certificate.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - pods
   verbs:
   - get
   - list
@@ -96,3 +97,29 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - podgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - workloads
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - workloads/finalizers
+  verbs:
+  - get
+  - patch
+  - update

--- a/internal/controller/workloadapi_controller.go
+++ b/internal/controller/workloadapi_controller.go
@@ -1,0 +1,685 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sevents "k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	availabilityv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+	"github.com/pdb-operator/pdb-operator/internal/cache"
+	"github.com/pdb-operator/pdb-operator/internal/events"
+	"github.com/pdb-operator/pdb-operator/internal/logging"
+	"github.com/pdb-operator/pdb-operator/internal/metrics"
+	"github.com/pdb-operator/pdb-operator/internal/tracing"
+)
+
+const (
+	kindWorkload      = "Workload"
+	kindWorkloadLower = "workload"
+	kindPodGroup      = "PodGroup"
+	// WorkloadAPIGroup is the API group of the upstream Workload API (KEP-4671).
+	WorkloadAPIGroup   = "scheduling.k8s.io"
+	WorkloadAPIVersion = "v1beta1"
+	// PodGroupNameIndex indexes pods by spec.schedulingGroup.podGroupName.
+	PodGroupNameIndex = "spec.schedulingGroup.podGroupName"
+	// workloadPodsPollDelay retries reconciles that wait on pods appearing.
+	workloadPodsPollDelay = 30 * time.Second
+)
+
+// WorkloadGVK is the GroupVersionKind of the upstream Workload object.
+var WorkloadGVK = schema.GroupVersionKind{Group: WorkloadAPIGroup, Version: WorkloadAPIVersion, Kind: kindWorkload}
+
+// PodGroupGVK is the GroupVersionKind of the upstream PodGroup object.
+var PodGroupGVK = schema.GroupVersionKind{Group: WorkloadAPIGroup, Version: WorkloadAPIVersion, Kind: kindPodGroup}
+
+// NewWorkloadObject returns an empty unstructured Workload with its GVK set.
+func NewWorkloadObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(WorkloadGVK)
+	return u
+}
+
+// NewPodGroupObject returns an empty unstructured PodGroup with its GVK set.
+func NewPodGroupObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(PodGroupGVK)
+	return u
+}
+
+// gangTemplate is the parsed gang slice of one spec.podGroupTemplates entry.
+type gangTemplate struct {
+	Name       string
+	MinCount   int32
+	DisruptAll bool
+}
+
+// parseGangTemplates returns the gang templates, total template count, and composite count.
+func parseGangTemplates(u *unstructured.Unstructured) (gangs []gangTemplate, total int, composite int) {
+	if c, found, err := unstructured.NestedSlice(u.Object, "spec", "compositePodGroupTemplates"); err == nil && found {
+		composite = len(c)
+	}
+	tmpls, found, err := unstructured.NestedSlice(u.Object, "spec", "podGroupTemplates")
+	if err != nil || !found {
+		return nil, 0, composite
+	}
+	for _, t := range tmpls {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		total++
+		name, _, _ := unstructured.NestedString(tm, "name")
+		minCount, foundGang, err := unstructured.NestedInt64(tm, "schedulingPolicy", "gang", "minCount")
+		if err != nil || !foundGang {
+			continue
+		}
+		_, disruptAll, _ := unstructured.NestedMap(tm, "disruptionMode", "all")
+		gangs = append(gangs, gangTemplate{Name: name, MinCount: int32(minCount), DisruptAll: disruptAll})
+	}
+	return gangs, total, composite
+}
+
+// workloadAPIObject adapts an unstructured Workload to WorkloadAccessor.
+// Selector and replicas are derived from the observed pods at reconcile time.
+type workloadAPIObject struct {
+	*unstructured.Unstructured
+	selector *metav1.LabelSelector
+	pods     int32
+}
+
+func (w *workloadAPIObject) GetObject() client.Object { return w.Unstructured }
+func (w *workloadAPIObject) GetName() string          { return w.Unstructured.GetName() }
+func (w *workloadAPIObject) GetNamespace() string     { return w.Unstructured.GetNamespace() }
+func (w *workloadAPIObject) GetAnnotations() map[string]string {
+	return w.Unstructured.GetAnnotations()
+}
+func (w *workloadAPIObject) GetLabels() map[string]string  { return w.Unstructured.GetLabels() }
+func (w *workloadAPIObject) GetGeneration() int64          { return w.Unstructured.GetGeneration() }
+func (w *workloadAPIObject) DeepCopyObject() client.Object { return w.DeepCopy() }
+func (w *workloadAPIObject) Kind() string                  { return kindWorkload }
+func (w *workloadAPIObject) KindLower() string             { return kindWorkloadLower }
+func (w *workloadAPIObject) GetReplicas() int32            { return w.pods }
+func (w *workloadAPIObject) GetSelector() *metav1.LabelSelector {
+	return w.selector
+}
+
+func (w *workloadAPIObject) GetDeletionTimestamp() *metav1.Time {
+	return w.Unstructured.GetDeletionTimestamp()
+}
+
+// deriveGroupSelector intersects the labels of all group pods into a candidate selector.
+// It returns nil when no candidate exists or the candidate matches pods outside the group.
+func deriveGroupSelector(pods []corev1.Pod, allInNamespace []corev1.Pod) map[string]string {
+	if len(pods) == 0 {
+		return nil
+	}
+	candidate := map[string]string{}
+	for k, v := range pods[0].Labels {
+		candidate[k] = v
+	}
+	for _, p := range pods[1:] {
+		for k, v := range candidate {
+			if p.Labels[k] != v {
+				delete(candidate, k)
+			}
+		}
+	}
+	if len(candidate) == 0 {
+		return nil
+	}
+	// exactness: the candidate must select the group pods and nothing else
+	member := make(map[types.UID]bool, len(pods))
+	for _, p := range pods {
+		member[p.UID] = true
+	}
+	sel := labels.SelectorFromSet(candidate)
+	for _, p := range allInNamespace {
+		if sel.Matches(labels.Set(p.Labels)) && !member[p.UID] {
+			return nil
+		}
+	}
+	return candidate
+}
+
+// WorkloadAPIReconciler manages PDBs for upstream Workload objects (scheduling.k8s.io/v1beta1).
+type WorkloadAPIReconciler struct {
+	client.Client
+	Scheme      *runtime.Scheme
+	Recorder    k8sevents.EventRecorder
+	Events      *events.EventRecorder
+	PolicyCache *cache.PolicyCache
+	Config      *SharedConfig
+	// Clock is injectable for deterministic maintenance-window tests; defaults to real time.
+	Clock clock.PassiveClock
+
+	tracker *WorkloadStateTracker
+}
+
+func (r *WorkloadAPIReconciler) now() time.Time {
+	if r.Clock != nil {
+		return r.Clock.Now()
+	}
+	return time.Now()
+}
+
+// +kubebuilder:rbac:groups=scheduling.k8s.io,resources=workloads;podgroups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=scheduling.k8s.io,resources=workloads,verbs=update;patch
+// +kubebuilder:rbac:groups=scheduling.k8s.io,resources=workloads/finalizers,verbs=get;patch;update
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+
+// Reconcile derives gang-aware PDBs from a Workload's pod groups and pods.
+func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	startTime := time.Now()
+
+	ctx, span := tracing.ReconcileSpan(ctx, kindWorkloadLower, req.Namespace, req.Name)
+	defer span.End()
+
+	reconcileID := kindWorkloadLower + "-" + uuid.New().String()
+	correlationID := uuid.New().String()
+
+	span.SetAttributes(
+		attribute.String("reconcile.id", reconcileID),
+		attribute.String("correlation.id", correlationID),
+	)
+
+	logger := logging.CreateUnifiedLogger(ctx,
+		"workload-pdb", "workload-controller", WorkloadAPIGroup, kindWorkload,
+		kindWorkloadLower, req.Name, req.Namespace, reconcileID, correlationID,
+	)
+
+	var reconcileErr error
+	defer func() {
+		duration := time.Since(startTime)
+		metrics.RecordReconciliation(kindWorkloadLower, duration, reconcileErr)
+		if reconcileErr != nil {
+			tracing.RecordError(span, reconcileErr, "Reconciliation failed")
+		}
+		result := logging.AuditResultSuccess
+		if reconcileErr != nil {
+			result = logging.AuditResultFailure
+		}
+		logger.Audit("RECONCILE", fmt.Sprintf("%s/%s", req.Namespace, req.Name), kindWorkloadLower,
+			req.Namespace, req.Name, result, map[string]interface{}{
+				"controller": kindWorkloadLower,
+				"duration":   time.Since(startTime).String(),
+				"durationMs": time.Since(startTime).Milliseconds(),
+			})
+		logger.Info("Reconciliation completed", map[string]any{"duration": time.Since(startTime).String()})
+	}()
+
+	workload := NewWorkloadObject()
+	if err := r.Get(ctx, req.NamespacedName, workload); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Workload not found, ignoring since object must be deleted", map[string]any{})
+			return ctrl.Result{}, nil
+		}
+		reconcileErr = err
+		logger.Error(err, "Failed to get Workload", map[string]any{})
+		return ctrl.Result{}, err
+	}
+
+	w := &workloadAPIObject{Unstructured: workload}
+
+	if w.GetDeletionTimestamp() != nil {
+		logger.Info("Workload is being deleted", map[string]any{})
+		r.tracker.ClearState(w)
+		tracing.AddEvent(ctx, "DeletingPDB")
+		if err := HandleDeletion(ctx, r.Client, r.Events, w, logger.ToLogr()); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	gangs, total, composite := parseGangTemplates(workload)
+	if len(gangs) == 0 {
+		// basic-only workloads are owned by the pod-owning controller's native path
+		logger.Info("No gang pod group templates, skipping", map[string]any{"templates": total})
+		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+	if len(gangs) > 1 || composite > 0 {
+		r.warnSkip(w, "Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
+		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+	gang := gangs[0]
+
+	groups, groupPods, err := r.collectTemplatePods(ctx, w.GetNamespace(), w.GetName(), gang.Name)
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "Failed to collect pod groups", map[string]any{})
+		return ctrl.Result{}, err
+	}
+
+	if len(groupPods) == 0 {
+		r.warnSkip(w, "No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
+		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
+	}
+
+	for i := range groupPods {
+		// pods with a native gang path (today: LWS) already have a group-aware PDB
+		if _, owned := groupPods[i].Labels[LWSSetNameLabelKey]; owned {
+			logger.Info("Pods are managed by a native gang path, skipping", map[string]any{})
+			return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+		}
+	}
+
+	allPods := &corev1.PodList{}
+	if err := r.List(ctx, allPods, client.InNamespace(w.GetNamespace())); err != nil {
+		reconcileErr = err
+		return ctrl.Result{}, err
+	}
+	selectorLabels := deriveGroupSelector(groupPods, allPods.Items)
+	if selectorLabels == nil {
+		r.warnSkip(w, "No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
+		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
+	}
+	w.selector = &metav1.LabelSelector{MatchLabels: selectorLabels}
+	w.pods = int32(len(groupPods))
+
+	maxGroupSize := int32(0)
+	for _, pods := range groups {
+		if int32(len(pods)) > maxGroupSize {
+			maxGroupSize = int32(len(pods))
+		}
+	}
+
+	if gang.DisruptAll && len(groups) < 2 {
+		// a single all-mode group has no valid PDB: any budget permanently blocks drains
+		r.warnSkip(w,
+			"No PDB created for %s: a single pod group with disruptionMode all restarts as a unit, so any PDB would permanently block node drains",
+			w.GetName())
+		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
+		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+
+	tracing.AddEvent(ctx, "EvaluatingPolicies")
+
+	config, err := GetAvailabilityConfigWithCache(ctx, r.Client, r.PolicyCache, r.Events, w, logger.ToLogr())
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "Failed to get availability configuration", map[string]any{})
+		return ctrl.Result{}, err
+	}
+
+	if config == nil {
+		logger.Info("No availability configuration found, skipping PDB", map[string]any{})
+		if r.Events != nil {
+			r.Events.Infof(workload, "WorkloadUnmanaged",
+				"Workload %s has no availability configuration", w.GetName())
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if gang.DisruptAll {
+		// the whole group restarts together, so quantize the budget to whole groups
+		config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, int32(len(groups)), maxGroupSize)
+	} else if len(groups) == 1 {
+		// a single independently-disrupted gang keeps pod semantics floored at minCount
+		floored, ok := floorAtMinCount(config.MinAvailable, gang.MinCount, w.pods)
+		if !ok {
+			r.warnSkip(w,
+				"No PDB created for %s: gang minCount %d leaves no pod evictable, so any PDB would permanently block node drains",
+				w.GetName(), gang.MinCount)
+			metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "min_count_blocks_drains")
+			return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+		}
+		config.MinAvailable = floored
+	}
+
+	// add the finalizer before the state-change guard so an out-of-band removal is always restored
+	if !controllerutil.ContainsFinalizer(workload, FinalizerPDBCleanup) {
+		patch := client.MergeFrom(workload.DeepCopy())
+		controllerutil.AddFinalizer(workload, FinalizerPDBCleanup)
+		if err := r.Patch(ctx, workload, patch); err != nil {
+			reconcileErr = err
+			logger.Error(err, "Failed to add finalizer", map[string]any{})
+			return ctrl.Result{}, err
+		}
+		logger.Info("Added finalizer for PDB cleanup", map[string]any{})
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	stateChanged, err := r.tracker.HasStateChanged(ctx, r.Client, w, config)
+	if err != nil {
+		logger.Error(err, "Failed to check workload state changes, proceeding with reconciliation", map[string]any{})
+		stateChanged = true
+	}
+	if !stateChanged {
+		logger.Info("Skipping reconciliation - no state change detected", map[string]any{
+			"availabilityClass": string(config.AvailabilityClass),
+			"reason":            "no_state_change",
+		})
+		return ctrl.Result{}, nil
+	}
+
+	if IsInMaintenanceWindow(config, r.now()) {
+		logger.Info("In maintenance window, temporarily relaxing PDB", map[string]any{
+			"maintenanceWindow": config.MaintenanceWindow,
+		})
+		if err := RemovePDBTemporarily(ctx, r.Client, w, log.FromContext(ctx)); err != nil {
+			reconcileErr = err
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+		}
+		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	}
+
+	// never adopt a PDB owned by another kind
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	pdbKey := types.NamespacedName{Name: w.GetName() + DefaultPDBSuffix, Namespace: w.GetNamespace()}
+	if err := r.Get(ctx, pdbKey, existingPDB); err == nil {
+		if ref := metav1.GetControllerOf(existingPDB); ref != nil && ref.Kind != kindWorkload {
+			logger.Info("PDB name is held by another owner, waiting for its controller to release it", map[string]any{
+				"pdb": pdbKey.Name, "ownerKind": ref.Kind, "ownerName": ref.Name,
+			})
+			return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, nil
+		}
+	}
+
+	result, err := ReconcilePDB(ctx, r.Client, r.Scheme, r.Events, w, config, log.FromContext(ctx))
+	if err != nil {
+		reconcileErr = err
+		logger.Error(err, "PDB reconciliation failed, will retry", map[string]any{})
+		return ctrl.Result{RequeueAfter: DefaultRequeueDelay}, err
+	}
+
+	metrics.ManagedWorkloads.WithLabelValues(w.GetNamespace(), string(config.AvailabilityClass)).Set(1)
+	metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), true, "managed")
+	if err := r.tracker.UpdateState(ctx, r.Client, w, config); err != nil {
+		logger.Error(err, "Failed to update workload state cache", map[string]any{})
+	}
+
+	logger.Info("Successfully reconciled PDB", map[string]any{
+		"availabilityClass": config.AvailabilityClass,
+		"source":            config.Source,
+		"reconcileID":       reconcileID,
+	})
+
+	return applyMaintenanceRequeue(result, config, r.now()), nil
+}
+
+// floorAtMinCount resolves minAvailable to an absolute pod count no lower than minCount.
+// ok is false when the floor leaves no pod evictable.
+func floorAtMinCount(minAvailable intstr.IntOrString, minCount, totalPods int32) (intstr.IntOrString, bool) {
+	scaled, err := intstr.GetScaledValueFromIntOrPercent(&minAvailable, int(totalPods), true)
+	if err != nil {
+		scaled = 0
+	}
+	floored := int32(scaled)
+	if minCount > floored {
+		floored = minCount
+	}
+	if floored >= totalPods {
+		return minAvailable, false
+	}
+	return intstr.FromInt32(floored), true
+}
+
+// collectTemplatePods returns pods per PodGroup of the template, and all of them flattened.
+func (r *WorkloadAPIReconciler) collectTemplatePods(ctx context.Context, namespace, workloadName, templateName string) (map[string][]corev1.Pod, []corev1.Pod, error) {
+	pgList := &unstructured.UnstructuredList{}
+	pgList.SetGroupVersionKind(PodGroupGVK.GroupVersion().WithKind(kindPodGroup + "List"))
+	if err := r.List(ctx, pgList, client.InNamespace(namespace)); err != nil {
+		return nil, nil, err
+	}
+
+	groups := map[string][]corev1.Pod{}
+	var all []corev1.Pod
+	for i := range pgList.Items {
+		pg := &pgList.Items[i]
+		wName, _, _ := unstructured.NestedString(pg.Object, "spec", "workloadRef", "workloadName")
+		tName, _, _ := unstructured.NestedString(pg.Object, "spec", "workloadRef", "templateName")
+		if wName != workloadName || tName != templateName {
+			continue
+		}
+		podList := &corev1.PodList{}
+		if err := r.List(ctx, podList, client.InNamespace(namespace),
+			client.MatchingFields{PodGroupNameIndex: pg.GetName()}); err != nil {
+			return nil, nil, err
+		}
+		groups[pg.GetName()] = podList.Items
+		all = append(all, podList.Items...)
+	}
+	return groups, all, nil
+}
+
+func (r *WorkloadAPIReconciler) warnSkip(w *workloadAPIObject, format string, args ...interface{}) {
+	if r.Events != nil {
+		r.Events.Warnf(w.Unstructured, "WorkloadSkipped", format, args...)
+	}
+}
+
+// cleanupQuietly removes a previously created PDB when the workload no longer qualifies.
+func (r *WorkloadAPIReconciler) cleanupQuietly(ctx context.Context, w *workloadAPIObject, logger *logging.UnifiedLogger) error {
+	if err := CleanupPDB(ctx, r.Client, r.Events, w, logger.ToLogr()); err != nil {
+		logger.Error(err, "Failed to clean up PDB", map[string]any{})
+		return err
+	}
+	return nil
+}
+
+// SetupWithManager sets up the Workload API controller with the Manager.
+func (r *WorkloadAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	maxConcurrent := 3
+	if r.Config != nil && r.Config.MaxConcurrentReconciles > 0 {
+		maxConcurrent = r.Config.MaxConcurrentReconciles
+	}
+	return r.SetupWithManagerWithOptions(mgr, controller.Options{
+		MaxConcurrentReconciles: maxConcurrent,
+	})
+}
+
+// SetupWithManagerWithOptions sets up the controller with custom options.
+func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, opts controller.Options) error {
+	r.tracker = NewWorkloadStateTracker()
+
+	if r.Recorder == nil && mgr != nil {
+		r.Recorder = mgr.GetEventRecorder("workload-pdb-controller")
+	}
+	if r.Events == nil && r.Recorder != nil {
+		r.Events = events.NewEventRecorder(r.Recorder)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, PodGroupNameIndex,
+		func(obj client.Object) []string {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok || pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
+				return nil
+			}
+			return []string{*pod.Spec.SchedulingGroup.PodGroupName}
+		}); err != nil {
+		return err
+	}
+
+	workloadPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return isWorkloadObject(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !isWorkloadObject(e.ObjectOld) || !isWorkloadObject(e.ObjectNew) {
+				return false
+			}
+			if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
+				return e.ObjectOld.GetDeletionTimestamp() == nil && e.ObjectNew.GetDeletionTimestamp() != nil
+			}
+			return true
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	podGroupHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil
+		}
+		wName, _, _ := unstructured.NestedString(u.Object, "spec", "workloadRef", "workloadName")
+		if wName == "" {
+			return nil
+		}
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{Name: wName, Namespace: u.GetNamespace()},
+		}}
+	})
+
+	podHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok || pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
+			return nil
+		}
+		pg := NewPodGroupObject()
+		key := types.NamespacedName{Name: *pod.Spec.SchedulingGroup.PodGroupName, Namespace: pod.Namespace}
+		if err := r.Get(ctx, key, pg); err != nil {
+			return nil
+		}
+		wName, _, _ := unstructured.NestedString(pg.Object, "spec", "workloadRef", "workloadName")
+		if wName == "" {
+			return nil
+		}
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{Name: wName, Namespace: pod.Namespace},
+		}}
+	})
+
+	podPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return podInSchedulingGroup(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !podInSchedulingGroup(e.ObjectNew) {
+				return false
+			}
+			// selector derivation and pod counts only depend on labels and existence
+			return !labels.Equals(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels())
+		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return podInSchedulingGroup(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	pdbHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		pdb, ok := obj.(*policyv1.PodDisruptionBudget)
+		if !ok {
+			return nil
+		}
+		if pdbLabels := pdb.GetLabels(); pdbLabels == nil || pdbLabels[LabelManagedBy] != OperatorName {
+			return nil
+		}
+		ownerRef := metav1.GetControllerOf(pdb)
+		if ownerRef == nil || ownerRef.Kind != kindWorkload {
+			return nil
+		}
+		return []ctrl.Request{{
+			NamespacedName: types.NamespacedName{Name: ownerRef.Name, Namespace: pdb.Namespace},
+		}}
+	})
+
+	pdbPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			pdb, ok := e.ObjectNew.(*policyv1.PodDisruptionBudget)
+			if !ok {
+				return false
+			}
+			if pdbLabels := pdb.GetLabels(); pdbLabels != nil && pdbLabels[LabelManagedBy] == OperatorName {
+				oldPDB := e.ObjectOld.(*policyv1.PodDisruptionBudget)
+				return !isPDBUpdateByUs(oldPDB, pdb)
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			pdb, ok := e.Object.(*policyv1.PodDisruptionBudget)
+			if !ok {
+				return false
+			}
+			if pdbLabels := pdb.GetLabels(); pdbLabels != nil {
+				return pdbLabels[LabelManagedBy] == OperatorName
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	policyHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		policy, ok := obj.(*availabilityv1alpha1.PDBPolicy)
+		if !ok {
+			return nil
+		}
+		logger := log.FromContext(ctx)
+		wList := &unstructured.UnstructuredList{}
+		wList.SetGroupVersionKind(WorkloadGVK.GroupVersion().WithKind(kindWorkload + "List"))
+		if err := r.List(ctx, wList); err != nil {
+			logger.Error(err, "Failed to list Workloads for policy change")
+			return nil
+		}
+		var requests []ctrl.Request
+		for i := range wList.Items {
+			if PolicyMatchesWorkload(policy, &workloadAPIObject{Unstructured: &wList.Items[i]}) {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{Name: wList.Items[i].GetName(), Namespace: wList.Items[i].GetNamespace()},
+				})
+			}
+		}
+		return requests
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("workload-pdb").
+		For(NewWorkloadObject(), builder.WithPredicates(workloadPredicate)).
+		Watches(NewPodGroupObject(), podGroupHandler).
+		Watches(&corev1.Pod{}, podHandler, builder.WithPredicates(podPredicate)).
+		Watches(&policyv1.PodDisruptionBudget{}, pdbHandler, builder.WithPredicates(pdbPredicate)).
+		Watches(&availabilityv1alpha1.PDBPolicy{}, policyHandler).
+		WithOptions(opts).
+		Complete(r)
+}
+
+func isWorkloadObject(obj client.Object) bool {
+	u, ok := obj.(*unstructured.Unstructured)
+	return ok && u.GroupVersionKind() == WorkloadGVK
+}
+
+func podInSchedulingGroup(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	return ok && pod.Spec.SchedulingGroup != nil && pod.Spec.SchedulingGroup.PodGroupName != nil
+}

--- a/internal/controller/workloadapi_controller.go
+++ b/internal/controller/workloadapi_controller.go
@@ -271,71 +271,10 @@ func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	gangs, total, composite := parseGangTemplates(workload)
-	if len(gangs) == 0 {
-		// basic-only workloads are owned by the pod-owning controller's native path
-		logger.Info("No gang pod group templates, skipping", map[string]any{"templates": total})
-		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
-	}
-	if len(gangs) > 1 || composite > 0 {
-		r.warnSkip(w, "Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
-		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
-	}
-	gang := gangs[0]
-
-	groups, groupPods, err := r.collectTemplatePods(ctx, w.GetNamespace(), w.GetName(), gang.Name)
-	if err != nil {
+	in, done, res, err := r.prepareGangInput(ctx, w, logger)
+	if done || err != nil {
 		reconcileErr = err
-		logger.Error(err, "Failed to collect pod groups", map[string]any{})
-		return ctrl.Result{}, err
-	}
-
-	if len(groupPods) == 0 {
-		r.warnSkip(w, "No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
-		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
-	}
-
-	for i := range groupPods {
-		// pods with a native gang path (today: LWS) already have a group-aware PDB
-		if _, owned := groupPods[i].Labels[LWSSetNameLabelKey]; owned {
-			logger.Info("Pods are managed by a native gang path, skipping", map[string]any{})
-			return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
-		}
-	}
-
-	allPods := &corev1.PodList{}
-	if err := r.List(ctx, allPods, client.InNamespace(w.GetNamespace())); err != nil {
-		reconcileErr = err
-		return ctrl.Result{}, err
-	}
-	selectorLabels := deriveGroupSelector(groupPods, allPods.Items)
-	if selectorLabels == nil {
-		r.warnSkip(w, "No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
-		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
-	}
-	w.selector = &metav1.LabelSelector{MatchLabels: selectorLabels}
-	w.pods = int32(len(groupPods))
-
-	maxGroupSize := int32(0)
-	for _, pods := range groups {
-		if int32(len(pods)) > maxGroupSize {
-			maxGroupSize = int32(len(pods))
-		}
-	}
-
-	if gang.DisruptAll && len(groups) < 2 {
-		// a single all-mode group has no valid PDB: any budget permanently blocks drains
-		r.warnSkip(w,
-			"No PDB created for %s: a single pod group with disruptionMode all restarts as a unit, so any PDB would permanently block node drains",
-			w.GetName())
-		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
-		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+		return res, err
 	}
 
 	tracing.AddEvent(ctx, "EvaluatingPolicies")
@@ -356,20 +295,8 @@ func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	if gang.DisruptAll {
-		// the whole group restarts together, so quantize the budget to whole groups
-		config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, int32(len(groups)), maxGroupSize)
-	} else if len(groups) == 1 {
-		// a single independently-disrupted gang keeps pod semantics floored at minCount
-		floored, ok := floorAtMinCount(config.MinAvailable, gang.MinCount, w.pods)
-		if !ok {
-			r.warnSkip(w,
-				"No PDB created for %s: gang minCount %d leaves no pod evictable, so any PDB would permanently block node drains",
-				w.GetName(), gang.MinCount)
-			metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "min_count_blocks_drains")
-			return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
-		}
-		config.MinAvailable = floored
+	if !r.applyGangBudget(config, in, w) {
+		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 
 	// add the finalizer before the state-change guard so an out-of-band removal is always restored
@@ -441,6 +368,107 @@ func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	})
 
 	return applyMaintenanceRequeue(result, config, r.now()), nil
+}
+
+// gangReconcileInput is the gang shape Reconcile derives from templates, pod groups, and pods.
+type gangReconcileInput struct {
+	gang         gangTemplate
+	groupCount   int32
+	maxGroupSize int32
+}
+
+// prepareGangInput parses the gang shape and derives the pod-based selector onto w.
+// done=true means Reconcile should return res immediately.
+func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloadAPIObject,
+	logger *logging.UnifiedLogger) (in gangReconcileInput, done bool, res ctrl.Result, err error) {
+	gangs, total, composite := parseGangTemplates(w.Unstructured)
+	if len(gangs) == 0 {
+		// basic-only workloads are owned by the pod-owning controller's native path
+		logger.Info("No gang pod group templates, skipping", map[string]any{"templates": total})
+		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+	if len(gangs) > 1 || composite > 0 {
+		r.warnSkip(w, "Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
+		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+	in.gang = gangs[0]
+
+	groups, groupPods, err := r.collectTemplatePods(ctx, w.GetNamespace(), w.GetName(), in.gang.Name)
+	if err != nil {
+		logger.Error(err, "Failed to collect pod groups", map[string]any{})
+		return in, true, ctrl.Result{}, err
+	}
+
+	if len(groupPods) == 0 {
+		r.warnSkip(w, "No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
+		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
+			return in, true, ctrl.Result{}, err
+		}
+		return in, true, ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
+	}
+
+	for i := range groupPods {
+		// pods with a native gang path (today: LWS) already have a group-aware PDB
+		if _, owned := groupPods[i].Labels[LWSSetNameLabelKey]; owned {
+			logger.Info("Pods are managed by a native gang path, skipping", map[string]any{})
+			return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+		}
+	}
+
+	allPods := &corev1.PodList{}
+	if err := r.List(ctx, allPods, client.InNamespace(w.GetNamespace())); err != nil {
+		return in, true, ctrl.Result{}, err
+	}
+	selectorLabels := deriveGroupSelector(groupPods, allPods.Items)
+	if selectorLabels == nil {
+		r.warnSkip(w, "No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
+		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
+			return in, true, ctrl.Result{}, err
+		}
+		return in, true, ctrl.Result{RequeueAfter: workloadPodsPollDelay}, nil
+	}
+	w.selector = &metav1.LabelSelector{MatchLabels: selectorLabels}
+	w.pods = int32(len(groupPods))
+
+	in.groupCount = int32(len(groups))
+	for _, pods := range groups {
+		if int32(len(pods)) > in.maxGroupSize {
+			in.maxGroupSize = int32(len(pods))
+		}
+	}
+
+	if in.gang.DisruptAll && in.groupCount < 2 {
+		// a single all-mode group has no valid PDB: any budget permanently blocks drains
+		r.warnSkip(w,
+			"No PDB created for %s: a single pod group with disruptionMode all restarts as a unit, so any PDB would permanently block node drains",
+			w.GetName())
+		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
+		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
+	}
+	return in, false, ctrl.Result{}, nil
+}
+
+// applyGangBudget rewrites config.MinAvailable for the gang shape; false means no valid PDB exists.
+func (r *WorkloadAPIReconciler) applyGangBudget(config *AvailabilityConfig, in gangReconcileInput, w *workloadAPIObject) bool {
+	if in.gang.DisruptAll {
+		// the whole group restarts together, so quantize the budget to whole groups
+		config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, in.groupCount, in.maxGroupSize)
+		return true
+	}
+	if in.groupCount != 1 {
+		return true
+	}
+	// a single independently-disrupted gang keeps pod semantics floored at minCount
+	floored, ok := floorAtMinCount(config.MinAvailable, in.gang.MinCount, w.pods)
+	if !ok {
+		r.warnSkip(w,
+			"No PDB created for %s: gang minCount %d leaves no pod evictable, so any PDB would permanently block node drains",
+			w.GetName(), in.gang.MinCount)
+		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "min_count_blocks_drains")
+		return false
+	}
+	config.MinAvailable = floored
+	return true
 }
 
 // floorAtMinCount resolves minAvailable to an absolute pod count no lower than minCount.
@@ -536,7 +564,19 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 		return err
 	}
 
-	workloadPredicate := predicate.Funcs{
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("workload-pdb").
+		For(NewWorkloadObject(), builder.WithPredicates(workloadChangePredicate())).
+		Watches(NewPodGroupObject(), podGroupToWorkloadHandler()).
+		Watches(&corev1.Pod{}, r.podToWorkloadHandler(), builder.WithPredicates(groupPodPredicate())).
+		Watches(&policyv1.PodDisruptionBudget{}, workloadPDBHandler(), builder.WithPredicates(managedWorkloadPDBPredicate())).
+		Watches(&availabilityv1alpha1.PDBPolicy{}, r.policyToWorkloadsHandler()).
+		WithOptions(opts).
+		Complete(r)
+}
+
+func workloadChangePredicate() predicate.Funcs {
+	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return isWorkloadObject(e.Object) },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if !isWorkloadObject(e.ObjectOld) || !isWorkloadObject(e.ObjectNew) {
@@ -550,8 +590,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
+}
 
-	podGroupHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+func podGroupToWorkloadHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 		u, ok := obj.(*unstructured.Unstructured)
 		if !ok {
 			return nil
@@ -564,8 +606,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 			NamespacedName: types.NamespacedName{Name: wName, Namespace: u.GetNamespace()},
 		}}
 	})
+}
 
-	podHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+func (r *WorkloadAPIReconciler) podToWorkloadHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 		pod, ok := obj.(*corev1.Pod)
 		if !ok || pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
 			return nil
@@ -583,8 +627,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 			NamespacedName: types.NamespacedName{Name: wName, Namespace: pod.Namespace},
 		}}
 	})
+}
 
-	podPredicate := predicate.Funcs{
+func groupPodPredicate() predicate.Funcs {
+	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return podInSchedulingGroup(e.Object) },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if !podInSchedulingGroup(e.ObjectNew) {
@@ -596,8 +642,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 		DeleteFunc:  func(e event.DeleteEvent) bool { return podInSchedulingGroup(e.Object) },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
+}
 
-	pdbHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+func workloadPDBHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 		pdb, ok := obj.(*policyv1.PodDisruptionBudget)
 		if !ok {
 			return nil
@@ -613,8 +661,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 			NamespacedName: types.NamespacedName{Name: ownerRef.Name, Namespace: pdb.Namespace},
 		}}
 	})
+}
 
-	pdbPredicate := predicate.Funcs{
+func managedWorkloadPDBPredicate() predicate.Funcs {
+	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return false },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			pdb, ok := e.ObjectNew.(*policyv1.PodDisruptionBudget)
@@ -639,8 +689,10 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 		},
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
+}
 
-	policyHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+func (r *WorkloadAPIReconciler) policyToWorkloadsHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 		policy, ok := obj.(*availabilityv1alpha1.PDBPolicy)
 		if !ok {
 			return nil
@@ -662,16 +714,6 @@ func (r *WorkloadAPIReconciler) SetupWithManagerWithOptions(mgr ctrl.Manager, op
 		}
 		return requests
 	})
-
-	return ctrl.NewControllerManagedBy(mgr).
-		Named("workload-pdb").
-		For(NewWorkloadObject(), builder.WithPredicates(workloadPredicate)).
-		Watches(NewPodGroupObject(), podGroupHandler).
-		Watches(&corev1.Pod{}, podHandler, builder.WithPredicates(podPredicate)).
-		Watches(&policyv1.PodDisruptionBudget{}, pdbHandler, builder.WithPredicates(pdbPredicate)).
-		Watches(&availabilityv1alpha1.PDBPolicy{}, policyHandler).
-		WithOptions(opts).
-		Complete(r)
 }
 
 func isWorkloadObject(obj client.Object) bool {

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -40,10 +40,10 @@ import (
 )
 
 // newTestWorkload builds an unstructured Workload with one gang template named "workers".
-func newTestWorkload(name, namespace string, minCount int64, disruptAll bool, annotations, labels map[string]string) *unstructured.Unstructured {
+func newTestWorkload(name string, minCount int64, disruptAll bool, annotations, labels map[string]string) *unstructured.Unstructured {
 	u := NewWorkloadObject()
 	u.SetName(name)
-	u.SetNamespace(namespace)
+	u.SetNamespace("default")
 	u.SetAnnotations(annotations)
 	u.SetLabels(labels)
 	u.SetGeneration(1)
@@ -111,29 +111,28 @@ func newWorkloadAPITestReconciler(objects ...client.Object) *WorkloadAPIReconcil
 }
 
 // gangFixture seeds G pod groups of S pods each for workload w's "workers" template.
-func gangFixture(workloadName, namespace string, groups, size int, podLabels map[string]string) []client.Object {
+func gangFixture(workloadName string, groups, size int, podLabels map[string]string) []client.Object {
 	var objs []client.Object
 	for g := 0; g < groups; g++ {
 		pgName := fmt.Sprintf("%s-workers-%d", workloadName, g)
-		objs = append(objs, newTestPodGroup(pgName, namespace, workloadName, "workers"))
+		objs = append(objs, newTestPodGroup(pgName, "default", workloadName, "workers"))
 		for p := 0; p < size; p++ {
-			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), namespace, pgName, podLabels))
+			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), "default", pgName, podLabels))
 		}
 	}
 	return objs
 }
 
-func reconcileWorkloadTwice(t *testing.T, r *WorkloadAPIReconciler, name, namespace string) reconcile.Result {
+// reconcileWorkloadTwice reconciles twice: once for the finalizer requeue, once for the PDB.
+func reconcileWorkloadTwice(t *testing.T, r *WorkloadAPIReconciler, name string) reconcile.Result {
 	t.Helper()
 	ctx := context.Background()
-	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}}
 
+	_, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
 	result, err := r.Reconcile(ctx, req)
 	require.NoError(t, err)
-	if result.Requeue {
-		result, err = r.Reconcile(ctx, req)
-		require.NoError(t, err)
-	}
 	return result
 }
 
@@ -147,7 +146,7 @@ func TestParseGangTemplates(t *testing.T) {
 		},
 	}, "spec", "podGroupTemplates")
 
-	multi := newTestWorkload("multi", "default", 2, true, nil, nil)
+	multi := newTestWorkload("multi", 2, true, nil, nil)
 	tmpls, _, _ := unstructured.NestedSlice(multi.Object, "spec", "podGroupTemplates")
 	tmpls = append(tmpls, map[string]interface{}{
 		"name": "second",
@@ -157,7 +156,7 @@ func TestParseGangTemplates(t *testing.T) {
 	})
 	_ = unstructured.SetNestedSlice(multi.Object, tmpls, "spec", "podGroupTemplates")
 
-	composite := newTestWorkload("composite", "default", 2, false, nil, nil)
+	composite := newTestWorkload("composite", 2, false, nil, nil)
 	_ = unstructured.SetNestedSlice(composite.Object, []interface{}{
 		map[string]interface{}{"name": "outer"},
 	}, "spec", "compositePodGroupTemplates")
@@ -171,7 +170,7 @@ func TestParseGangTemplates(t *testing.T) {
 	}{
 		{"no templates", NewWorkloadObject(), 0, 0, 0},
 		{"basic only", basic, 0, 1, 0},
-		{"single gang", newTestWorkload("w", "default", 4, true, nil, nil), 1, 1, 0},
+		{"single gang", newTestWorkload("w", 4, true, nil, nil), 1, 1, 0},
 		{"two gangs", multi, 2, 2, 0},
 		{"composite present", composite, 1, 1, 1},
 	}
@@ -184,13 +183,13 @@ func TestParseGangTemplates(t *testing.T) {
 		})
 	}
 
-	gangs, _, _ := parseGangTemplates(newTestWorkload("w", "default", 4, true, nil, nil))
+	gangs, _, _ := parseGangTemplates(newTestWorkload("w", 4, true, nil, nil))
 	require.Len(t, gangs, 1)
 	assert.Equal(t, "workers", gangs[0].Name)
 	assert.Equal(t, int32(4), gangs[0].MinCount)
 	assert.True(t, gangs[0].DisruptAll)
 
-	gangs, _, _ = parseGangTemplates(newTestWorkload("w", "default", 4, false, nil, nil))
+	gangs, _, _ = parseGangTemplates(newTestWorkload("w", 4, false, nil, nil))
 	require.Len(t, gangs, 1)
 	assert.False(t, gangs[0].DisruptAll, "unset disruptionMode defaults to single")
 }
@@ -256,7 +255,7 @@ func TestFloorAtMinCount(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_AllMode_QuantizedPDB(t *testing.T) {
-	workload := newTestWorkload("trainer", "default", 2, true, nil, map[string]string{"tier": "training"})
+	workload := newTestWorkload("trainer", 2, true, nil, map[string]string{"tier": "training"})
 	policy := &pdbv1alpha1.PDBPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "training-policy", Namespace: "default"},
 		Spec: pdbv1alpha1.PDBPolicySpec{
@@ -265,11 +264,11 @@ func TestWorkloadAPIReconciler_AllMode_QuantizedPDB(t *testing.T) {
 			Priority:          10,
 		},
 	}
-	objs := append(gangFixture("trainer", "default", 4, 2, map[string]string{"app": "trainer"}),
+	objs := append(gangFixture("trainer", 4, 2, map[string]string{"app": "trainer"}),
 		workload, policy)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "trainer", "default")
+	reconcileWorkloadTwice(t, r, "trainer")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err := r.Get(context.Background(), types.NamespacedName{Name: "trainer-pdb", Namespace: "default"}, pdb)
@@ -290,12 +289,12 @@ func TestWorkloadAPIReconciler_AllMode_QuantizedPDB(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_SingleGroupAllMode_NoPDB(t *testing.T) {
-	workload := newTestWorkload("big-model", "default", 8, true,
+	workload := newTestWorkload("big-model", 8, true,
 		map[string]string{AnnotationAvailabilityClass: "mission-critical"}, nil)
-	objs := append(gangFixture("big-model", "default", 1, 8, map[string]string{"app": "big-model"}), workload)
+	objs := append(gangFixture("big-model", 1, 8, map[string]string{"app": "big-model"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "big-model", "default")
+	reconcileWorkloadTwice(t, r, "big-model")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err := r.Get(context.Background(), types.NamespacedName{Name: "big-model-pdb", Namespace: "default"}, pdb)
@@ -303,12 +302,12 @@ func TestWorkloadAPIReconciler_SingleGroupAllMode_NoPDB(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_NoPods_Defers(t *testing.T) {
-	workload := newTestWorkload("early", "default", 2, true,
+	workload := newTestWorkload("early", 2, true,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
 	pg := newTestPodGroup("early-workers-0", "default", "early", "workers")
 	r := newWorkloadAPITestReconciler(workload, pg)
 
-	result := reconcileWorkloadTwice(t, r, "early", "default")
+	result := reconcileWorkloadTwice(t, r, "early")
 	assert.Equal(t, workloadPodsPollDelay, result.RequeueAfter)
 
 	pdb := &policyv1.PodDisruptionBudget{}
@@ -317,12 +316,12 @@ func TestWorkloadAPIReconciler_NoPods_Defers(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_SingleMode_FloorsAtMinCount(t *testing.T) {
-	workload := newTestWorkload("etl", "default", 3, false,
+	workload := newTestWorkload("etl", 3, false,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
-	objs := append(gangFixture("etl", "default", 1, 6, map[string]string{"app": "etl"}), workload)
+	objs := append(gangFixture("etl", 1, 6, map[string]string{"app": "etl"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "etl", "default")
+	reconcileWorkloadTwice(t, r, "etl")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "etl-pdb", Namespace: "default"}, pdb))
@@ -331,12 +330,12 @@ func TestWorkloadAPIReconciler_SingleMode_FloorsAtMinCount(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_SingleMode_MinCountBlocksDrains_NoPDB(t *testing.T) {
-	workload := newTestWorkload("tight", "default", 4, false,
+	workload := newTestWorkload("tight", 4, false,
 		map[string]string{AnnotationAvailabilityClass: "non-critical"}, nil)
-	objs := append(gangFixture("tight", "default", 1, 4, map[string]string{"app": "tight"}), workload)
+	objs := append(gangFixture("tight", 1, 4, map[string]string{"app": "tight"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "tight", "default")
+	reconcileWorkloadTwice(t, r, "tight")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err := r.Get(context.Background(), types.NamespacedName{Name: "tight-pdb", Namespace: "default"}, pdb)
@@ -344,13 +343,13 @@ func TestWorkloadAPIReconciler_SingleMode_MinCountBlocksDrains_NoPDB(t *testing.
 }
 
 func TestWorkloadAPIReconciler_LWSOwnedPods_Skipped(t *testing.T) {
-	workload := newTestWorkload("lws-backed", "default", 2, true,
+	workload := newTestWorkload("lws-backed", 2, true,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
-	objs := append(gangFixture("lws-backed", "default", 2, 2,
+	objs := append(gangFixture("lws-backed", 2, 2,
 		map[string]string{"app": "lws-backed", LWSSetNameLabelKey: "lws-backed"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "lws-backed", "default")
+	reconcileWorkloadTwice(t, r, "lws-backed")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err := r.Get(context.Background(), types.NamespacedName{Name: "lws-backed-pdb", Namespace: "default"}, pdb)
@@ -358,7 +357,7 @@ func TestWorkloadAPIReconciler_LWSOwnedPods_Skipped(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_MultipleGangTemplates_Skipped(t *testing.T) {
-	workload := newTestWorkload("multi", "default", 2, true,
+	workload := newTestWorkload("multi", 2, true,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
 	tmpls, _, _ := unstructured.NestedSlice(workload.Object, "spec", "podGroupTemplates")
 	tmpls = append(tmpls, map[string]interface{}{
@@ -368,10 +367,10 @@ func TestWorkloadAPIReconciler_MultipleGangTemplates_Skipped(t *testing.T) {
 		},
 	})
 	_ = unstructured.SetNestedSlice(workload.Object, tmpls, "spec", "podGroupTemplates")
-	objs := append(gangFixture("multi", "default", 2, 2, map[string]string{"app": "multi"}), workload)
+	objs := append(gangFixture("multi", 2, 2, map[string]string{"app": "multi"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "multi", "default")
+	reconcileWorkloadTwice(t, r, "multi")
 
 	pdb := &policyv1.PodDisruptionBudget{}
 	err := r.Get(context.Background(), types.NamespacedName{Name: "multi-pdb", Namespace: "default"}, pdb)
@@ -379,12 +378,12 @@ func TestWorkloadAPIReconciler_MultipleGangTemplates_Skipped(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
-	workload := newTestWorkload("shrink", "default", 2, true,
+	workload := newTestWorkload("shrink", 2, true,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
-	objs := append(gangFixture("shrink", "default", 4, 2, map[string]string{"app": "shrink"}), workload)
+	objs := append(gangFixture("shrink", 4, 2, map[string]string{"app": "shrink"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "shrink", "default")
+	reconcileWorkloadTwice(t, r, "shrink")
 	pdb := &policyv1.PodDisruptionBudget{}
 	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb))
 
@@ -395,7 +394,7 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 		require.NoError(t, r.Delete(context.Background(), &pods.Items[i]))
 	}
 
-	result := reconcileWorkloadTwice(t, r, "shrink", "default")
+	result := reconcileWorkloadTwice(t, r, "shrink")
 	assert.Equal(t, workloadPodsPollDelay, result.RequeueAfter)
 
 	err := r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb)
@@ -403,12 +402,12 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 }
 
 func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {
-	workload := newTestWorkload("gone", "default", 2, true,
+	workload := newTestWorkload("gone", 2, true,
 		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
-	objs := append(gangFixture("gone", "default", 2, 2, map[string]string{"app": "gone"}), workload)
+	objs := append(gangFixture("gone", 2, 2, map[string]string{"app": "gone"}), workload)
 	r := newWorkloadAPITestReconciler(objs...)
 
-	reconcileWorkloadTwice(t, r, "gone", "default")
+	reconcileWorkloadTwice(t, r, "gone")
 	pdb := &policyv1.PodDisruptionBudget{}
 	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "gone-pdb", Namespace: "default"}, pdb))
 

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2025 The PDB Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sevents "k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	pdbv1alpha1 "github.com/pdb-operator/pdb-operator/api/v1alpha1"
+	"github.com/pdb-operator/pdb-operator/internal/events"
+)
+
+// newTestWorkload builds an unstructured Workload with one gang template named "workers".
+func newTestWorkload(name, namespace string, minCount int64, disruptAll bool, annotations, labels map[string]string) *unstructured.Unstructured {
+	u := NewWorkloadObject()
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetAnnotations(annotations)
+	u.SetLabels(labels)
+	u.SetGeneration(1)
+	tmpl := map[string]interface{}{
+		"name": "workers",
+		"schedulingPolicy": map[string]interface{}{
+			"gang": map[string]interface{}{"minCount": minCount},
+		},
+	}
+	if disruptAll {
+		tmpl["disruptionMode"] = map[string]interface{}{"all": map[string]interface{}{}}
+	}
+	_ = unstructured.SetNestedSlice(u.Object, []interface{}{tmpl}, "spec", "podGroupTemplates")
+	return u
+}
+
+// newTestPodGroup builds an unstructured PodGroup referencing a workload template.
+func newTestPodGroup(name, namespace, workloadName, templateName string) *unstructured.Unstructured {
+	u := NewPodGroupObject()
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_ = unstructured.SetNestedField(u.Object, workloadName, "spec", "workloadRef", "workloadName")
+	_ = unstructured.SetNestedField(u.Object, templateName, "spec", "workloadRef", "templateName")
+	return u
+}
+
+// newTestGroupPod builds a pod that references its PodGroup via spec.schedulingGroup.
+func newTestGroupPod(name, namespace, podGroupName string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			UID:       types.UID(namespace + "/" + name),
+		},
+		Spec: corev1.PodSpec{
+			SchedulingGroup: &corev1.PodSchedulingGroup{PodGroupName: &podGroupName},
+			Containers:      []corev1.Container{{Name: "app", Image: "app"}},
+		},
+	}
+}
+
+func newWorkloadAPITestReconciler(objects ...client.Object) *WorkloadAPIReconciler {
+	scheme := SetupTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&pdbv1alpha1.PDBPolicy{}).
+		WithIndex(&corev1.Pod{}, PodGroupNameIndex, func(obj client.Object) []string {
+			pod := obj.(*corev1.Pod)
+			if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
+				return nil
+			}
+			return []string{*pod.Spec.SchedulingGroup.PodGroupName}
+		}).
+		Build()
+	fakeRecorder := k8sevents.NewFakeRecorder(100)
+	return &WorkloadAPIReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: fakeRecorder,
+		Events:   events.NewEventRecorder(fakeRecorder),
+		tracker:  NewWorkloadStateTracker(),
+	}
+}
+
+// gangFixture seeds G pod groups of S pods each for workload w's "workers" template.
+func gangFixture(workloadName, namespace string, groups, size int, podLabels map[string]string) []client.Object {
+	var objs []client.Object
+	for g := 0; g < groups; g++ {
+		pgName := fmt.Sprintf("%s-workers-%d", workloadName, g)
+		objs = append(objs, newTestPodGroup(pgName, namespace, workloadName, "workers"))
+		for p := 0; p < size; p++ {
+			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), namespace, pgName, podLabels))
+		}
+	}
+	return objs
+}
+
+func reconcileWorkloadTwice(t *testing.T, r *WorkloadAPIReconciler, name, namespace string) reconcile.Result {
+	t.Helper()
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}
+
+	result, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	if result.Requeue {
+		result, err = r.Reconcile(ctx, req)
+		require.NoError(t, err)
+	}
+	return result
+}
+
+func TestParseGangTemplates(t *testing.T) {
+	basic := NewWorkloadObject()
+	basic.SetName("basic")
+	_ = unstructured.SetNestedSlice(basic.Object, []interface{}{
+		map[string]interface{}{
+			"name":             "web",
+			"schedulingPolicy": map[string]interface{}{"basic": map[string]interface{}{}},
+		},
+	}, "spec", "podGroupTemplates")
+
+	multi := newTestWorkload("multi", "default", 2, true, nil, nil)
+	tmpls, _, _ := unstructured.NestedSlice(multi.Object, "spec", "podGroupTemplates")
+	tmpls = append(tmpls, map[string]interface{}{
+		"name": "second",
+		"schedulingPolicy": map[string]interface{}{
+			"gang": map[string]interface{}{"minCount": int64(3)},
+		},
+	})
+	_ = unstructured.SetNestedSlice(multi.Object, tmpls, "spec", "podGroupTemplates")
+
+	composite := newTestWorkload("composite", "default", 2, false, nil, nil)
+	_ = unstructured.SetNestedSlice(composite.Object, []interface{}{
+		map[string]interface{}{"name": "outer"},
+	}, "spec", "compositePodGroupTemplates")
+
+	tests := []struct {
+		name          string
+		workload      *unstructured.Unstructured
+		wantGangs     int
+		wantTotal     int
+		wantComposite int
+	}{
+		{"no templates", NewWorkloadObject(), 0, 0, 0},
+		{"basic only", basic, 0, 1, 0},
+		{"single gang", newTestWorkload("w", "default", 4, true, nil, nil), 1, 1, 0},
+		{"two gangs", multi, 2, 2, 0},
+		{"composite present", composite, 1, 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gangs, total, composite := parseGangTemplates(tt.workload)
+			assert.Len(t, gangs, tt.wantGangs)
+			assert.Equal(t, tt.wantTotal, total)
+			assert.Equal(t, tt.wantComposite, composite)
+		})
+	}
+
+	gangs, _, _ := parseGangTemplates(newTestWorkload("w", "default", 4, true, nil, nil))
+	require.Len(t, gangs, 1)
+	assert.Equal(t, "workers", gangs[0].Name)
+	assert.Equal(t, int32(4), gangs[0].MinCount)
+	assert.True(t, gangs[0].DisruptAll)
+
+	gangs, _, _ = parseGangTemplates(newTestWorkload("w", "default", 4, false, nil, nil))
+	require.Len(t, gangs, 1)
+	assert.False(t, gangs[0].DisruptAll, "unset disruptionMode defaults to single")
+}
+
+func TestDeriveGroupSelector(t *testing.T) {
+	pods := func(labels ...map[string]string) []corev1.Pod {
+		out := make([]corev1.Pod, len(labels))
+		for i, l := range labels {
+			out[i] = *newTestGroupPod(fmt.Sprintf("p%d", i), "default", "pg", l)
+		}
+		return out
+	}
+
+	t.Run("common labels form the selector", func(t *testing.T) {
+		group := pods(
+			map[string]string{"app": "trainer", "role": "leader"},
+			map[string]string{"app": "trainer", "role": "worker"},
+		)
+		got := deriveGroupSelector(group, group)
+		assert.Equal(t, map[string]string{"app": "trainer"}, got)
+	})
+
+	t.Run("no pods yields nil", func(t *testing.T) {
+		assert.Nil(t, deriveGroupSelector(nil, nil))
+	})
+
+	t.Run("empty intersection yields nil", func(t *testing.T) {
+		group := pods(map[string]string{"a": "1"}, map[string]string{"b": "2"})
+		assert.Nil(t, deriveGroupSelector(group, group))
+	})
+
+	t.Run("over-matching candidate yields nil", func(t *testing.T) {
+		group := pods(map[string]string{"app": "trainer"}, map[string]string{"app": "trainer"})
+		stranger := *newTestGroupPod("stranger", "default", "other", map[string]string{"app": "trainer"})
+		assert.Nil(t, deriveGroupSelector(group, append(group, stranger)))
+	})
+}
+
+func TestFloorAtMinCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       intstr.IntOrString
+		minCount int32
+		total    int32
+		want     string
+		wantOK   bool
+	}{
+		{"class below floor is raised", intstr.FromString("50%"), 3, 4, "3", true},
+		{"class above floor wins", intstr.FromString("75%"), 3, 8, "6", true},
+		{"floor equals total blocks drains", intstr.FromString("50%"), 4, 4, "", false},
+		{"scaled rounds up to total blocks drains", intstr.FromString("90%"), 3, 8, "", false},
+		{"scaled equals total blocks drains", intstr.FromString("100%"), 1, 4, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := floorAtMinCount(tt.in, tt.minCount, tt.total)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}
+
+func TestWorkloadAPIReconciler_AllMode_QuantizedPDB(t *testing.T) {
+	workload := newTestWorkload("trainer", "default", 2, true, nil, map[string]string{"tier": "training"})
+	policy := &pdbv1alpha1.PDBPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "training-policy", Namespace: "default"},
+		Spec: pdbv1alpha1.PDBPolicySpec{
+			AvailabilityClass: pdbv1alpha1.MissionCritical,
+			WorkloadSelector:  pdbv1alpha1.WorkloadSelector{MatchLabels: map[string]string{"tier": "training"}},
+			Priority:          10,
+		},
+	}
+	objs := append(gangFixture("trainer", "default", 4, 2, map[string]string{"app": "trainer"}),
+		workload, policy)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "trainer", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "trainer-pdb", Namespace: "default"}, pdb)
+	require.NoError(t, err, "PDB should be created")
+
+	// 90% of 4 groups rounds up to 4, clamped to 3 groups x 2 pods = 6
+	assert.Equal(t, "6", pdb.Spec.MinAvailable.String())
+	assert.Equal(t, map[string]string{"app": "trainer"}, pdb.Spec.Selector.MatchLabels)
+
+	require.Len(t, pdb.OwnerReferences, 1)
+	assert.Equal(t, kindWorkload, pdb.OwnerReferences[0].Kind)
+	assert.Equal(t, "trainer", pdb.OwnerReferences[0].Name)
+	assert.Equal(t, WorkloadAPIGroup+"/"+WorkloadAPIVersion, pdb.OwnerReferences[0].APIVersion)
+
+	updated := NewWorkloadObject()
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "trainer", Namespace: "default"}, updated))
+	assert.Contains(t, updated.GetFinalizers(), FinalizerPDBCleanup)
+}
+
+func TestWorkloadAPIReconciler_SingleGroupAllMode_NoPDB(t *testing.T) {
+	workload := newTestWorkload("big-model", "default", 8, true,
+		map[string]string{AnnotationAvailabilityClass: "mission-critical"}, nil)
+	objs := append(gangFixture("big-model", "default", 1, 8, map[string]string{"app": "big-model"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "big-model", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "big-model-pdb", Namespace: "default"}, pdb)
+	assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "no PDB for a single all-mode group")
+}
+
+func TestWorkloadAPIReconciler_NoPods_Defers(t *testing.T) {
+	workload := newTestWorkload("early", "default", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	pg := newTestPodGroup("early-workers-0", "default", "early", "workers")
+	r := newWorkloadAPITestReconciler(workload, pg)
+
+	result := reconcileWorkloadTwice(t, r, "early", "default")
+	assert.Equal(t, workloadPodsPollDelay, result.RequeueAfter)
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "early-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "no PDB before pods exist")
+}
+
+func TestWorkloadAPIReconciler_SingleMode_FloorsAtMinCount(t *testing.T) {
+	workload := newTestWorkload("etl", "default", 3, false,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	objs := append(gangFixture("etl", "default", 1, 6, map[string]string{"app": "etl"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "etl", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "etl-pdb", Namespace: "default"}, pdb))
+	// standard (50%) of 6 pods = 3, tied with the gang minCount floor of 3
+	assert.Equal(t, "3", pdb.Spec.MinAvailable.String())
+}
+
+func TestWorkloadAPIReconciler_SingleMode_MinCountBlocksDrains_NoPDB(t *testing.T) {
+	workload := newTestWorkload("tight", "default", 4, false,
+		map[string]string{AnnotationAvailabilityClass: "non-critical"}, nil)
+	objs := append(gangFixture("tight", "default", 1, 4, map[string]string{"app": "tight"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "tight", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "tight-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "minCount == pod count leaves nothing evictable, no PDB")
+}
+
+func TestWorkloadAPIReconciler_LWSOwnedPods_Skipped(t *testing.T) {
+	workload := newTestWorkload("lws-backed", "default", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	objs := append(gangFixture("lws-backed", "default", 2, 2,
+		map[string]string{"app": "lws-backed", LWSSetNameLabelKey: "lws-backed"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "lws-backed", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "lws-backed-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "pods with a native gang path get no Workload API PDB")
+}
+
+func TestWorkloadAPIReconciler_MultipleGangTemplates_Skipped(t *testing.T) {
+	workload := newTestWorkload("multi", "default", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	tmpls, _, _ := unstructured.NestedSlice(workload.Object, "spec", "podGroupTemplates")
+	tmpls = append(tmpls, map[string]interface{}{
+		"name": "second",
+		"schedulingPolicy": map[string]interface{}{
+			"gang": map[string]interface{}{"minCount": int64(2)},
+		},
+	})
+	_ = unstructured.SetNestedSlice(workload.Object, tmpls, "spec", "podGroupTemplates")
+	objs := append(gangFixture("multi", "default", 2, 2, map[string]string{"app": "multi"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "multi", "default")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.Get(context.Background(), types.NamespacedName{Name: "multi-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "multi-template workloads are not yet supported")
+}
+
+func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
+	workload := newTestWorkload("shrink", "default", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	objs := append(gangFixture("shrink", "default", 4, 2, map[string]string{"app": "shrink"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "shrink", "default")
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb))
+
+	// simulate all pods disappearing (workload torn down but object kept)
+	pods := &corev1.PodList{}
+	require.NoError(t, r.List(context.Background(), pods, client.InNamespace("default")))
+	for i := range pods.Items {
+		require.NoError(t, r.Delete(context.Background(), &pods.Items[i]))
+	}
+
+	result := reconcileWorkloadTwice(t, r, "shrink", "default")
+	assert.Equal(t, workloadPodsPollDelay, result.RequeueAfter)
+
+	err := r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "PDB should be cleaned up when no pods remain")
+}
+
+func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {
+	workload := newTestWorkload("gone", "default", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	objs := append(gangFixture("gone", "default", 2, 2, map[string]string{"app": "gone"}), workload)
+	r := newWorkloadAPITestReconciler(objs...)
+
+	reconcileWorkloadTwice(t, r, "gone", "default")
+	pdb := &policyv1.PodDisruptionBudget{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "gone-pdb", Namespace: "default"}, pdb))
+
+	// the finalizer keeps the object around with a deletionTimestamp set
+	current := NewWorkloadObject()
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: "gone", Namespace: "default"}, current))
+	require.NoError(t, r.Delete(context.Background(), current))
+
+	_, err := r.Reconcile(context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"}})
+	require.NoError(t, err)
+
+	err = r.Get(context.Background(), types.NamespacedName{Name: "gone-pdb", Namespace: "default"}, pdb)
+	assert.Error(t, err, "PDB should be deleted with its Workload")
+
+	err = r.Get(context.Background(), types.NamespacedName{Name: "gone", Namespace: "default"}, NewWorkloadObject())
+	assert.Error(t, err, "Workload should be gone once the finalizer is removed")
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -95,6 +95,14 @@ var (
 		[]string{"namespace", "availability_class"},
 	)
 
+	ManagedWorkloads = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "pdb_operator_workloads_managed",
+			Help: "Current number of scheduling.k8s.io Workloads being managed",
+		},
+		[]string{"namespace", "availability_class"},
+	)
+
 	PDBComplianceStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "pdb_operator_compliance_status",
@@ -252,6 +260,7 @@ func init() {
 		ManagedDeployments,
 		ManagedStatefulSets,
 		ManagedLeaderWorkerSets,
+		ManagedWorkloads,
 		PDBComplianceStatus,
 		AvailabilityPoliciesActive,
 		MaintenanceWindowActive,
@@ -322,6 +331,15 @@ func UpdateManagedLeaderWorkerSets(counts map[string]map[string]int) {
 	for namespace, classCounts := range counts {
 		for class, count := range classCounts {
 			ManagedLeaderWorkerSets.WithLabelValues(namespace, class).Set(float64(count))
+		}
+	}
+}
+
+func UpdateManagedWorkloads(counts map[string]map[string]int) {
+	ManagedWorkloads.Reset()
+	for namespace, classCounts := range counts {
+		for class, count := range classCounts {
+			ManagedWorkloads.WithLabelValues(namespace, class).Set(float64(count))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Part of #95 (design resolved in [this comment](https://github.com/pdb-operator/pdb-operator/issues/95#issuecomment-5448947657), verified against the k8s `release-1.37` sources). Implements the discovery-gated controller; the kind 1.37 e2e follows in a separate PR.

## What it does

A new `WorkloadAPIReconciler` activates only when the cluster serves `scheduling.k8s.io/v1beta1` with both `Workload` and `PodGroup` (same startup-detection pattern as LWS). On clusters without the API the operator is byte-for-byte unchanged.

**Mapping** (per the design table on #95):

- `gang` + `disruptionMode: {all: {}}`: the group restarts as a unit, so the budget is quantized to whole pod groups, reusing `QuantizeMinAvailableForGroups` including the groups-1 clamp.
- `gang` + `single`/unset: pod-level semantics with `minAvailable` floored at the gang `minCount`.
- Drain-blocking shapes (single all-mode group; `minCount` or the scaled class covering every pod): no PDB, Warning event, mirroring the LWS `replicas: 1` rule.
- `basic` templates, multiple gang templates, and composite templates: skipped (the latter two with a Warning).

**Selector derivation**: pods reference their PodGroup via `spec.schedulingGroup.podGroupName` (a spec field, no label exists upstream), so the PDB selector is computed as the label intersection of the group's pods and validated to match exactly those pods; otherwise no PDB plus a Warning, retried on a 30s requeue. Pods carrying the LWS label are left to the native path so no pod ever matches two PDBs. Pods are cache-indexed on the schedulingGroup reference; the pod informer only exists when the controller is registered.

**Wiring**: availability class resolves on the `Workload` object (annotations + `PDBPolicy` label selectors), finalizer-based cleanup, maintenance windows, state-change tracking, and the non-adoption guard all reuse the shared workload path. New `pdb_operator_workloads_managed` gauge, recounted by the periodic updater (the #85 regression class is covered from day one).

## Verification

- `make test`: full unit suite green; new coverage for template parsing, selector derivation (incl. over-match rejection), minCount flooring, all-mode quantization (90% of 4x2 -> `minAvailable: 6`), single-group/multi-template/LWS-owned skips, pod-loss cleanup, and deletion.
- `make manifests` regenerated RBAC (pods read; workloads read+finalizers; podgroups read).

## Out of scope (tracked on #95)

- kind 1.37 e2e with `GenericWorkload` enabled (needs the suite's kind config to pin `kindest/node:v1.37.0` and enable the gate)
- composite / multi-template Workloads