### PR TITLE
fix: distinct event reasons per Workload skip cause, plus a log line per skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Workload skip warnings after the first are no longer swallowed. The events.k8s.io correlation key ignores the event message, so every skip cause sharing the `WorkloadSkipped` reason collapsed into the first warning's series and later messages (e.g. the single-group no-PDB explanation) were discarded. Each cause now has its own reason: `WorkloadPDBDeferred` (no pods yet), `WorkloadSelectorUnresolvable`, `WorkloadUnsupported` (multi/composite templates), `WorkloadSkipped` (no valid PDB possible), and every skip also writes a log line (#99, #98)
+
 ### Added
 - Gang-aware PDBs from the upstream Workload API (`scheduling.k8s.io/v1beta1`, KEP-4671, beta in Kubernetes 1.37 behind the `GenericWorkload` gate). `disruptionMode: all` templates get budgets quantized to whole pod groups (reusing the LWS math); `single` gangs keep pod semantics floored at the gang `minCount`; shapes whose budget would permanently block drains (single all-mode group, `minCount` covering every pod) get no PDB plus a Warning event. The PDB selector is derived from labels common to the group's pods and validated for exactness, since pods reference their PodGroup through `spec.schedulingGroup.podGroupName` rather than a label. Support activates only when the API is served (#95)
 

--- a/internal/controller/workloadapi_controller.go
+++ b/internal/controller/workloadapi_controller.go
@@ -295,7 +295,7 @@ func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	if !r.applyGangBudget(config, in, w) {
+	if !r.applyGangBudget(logger, config, in, w) {
 		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 
@@ -388,7 +388,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 	if len(gangs) > 1 || composite > 0 {
-		r.warnSkip(w, "Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
+		r.warnSkip(logger, w, "WorkloadUnsupported",
+			"Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
 		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 	in.gang = gangs[0]
@@ -400,7 +401,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 	}
 
 	if len(groupPods) == 0 {
-		r.warnSkip(w, "No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
+		r.warnSkip(logger, w, "WorkloadPDBDeferred",
+			"No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
 		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
 			return in, true, ctrl.Result{}, err
 		}
@@ -421,7 +423,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 	}
 	selectorLabels := deriveGroupSelector(groupPods, allPods.Items)
 	if selectorLabels == nil {
-		r.warnSkip(w, "No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
+		r.warnSkip(logger, w, "WorkloadSelectorUnresolvable",
+			"No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
 		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
 			return in, true, ctrl.Result{}, err
 		}
@@ -439,7 +442,7 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 
 	if in.gang.DisruptAll && in.groupCount < 2 {
 		// a single all-mode group has no valid PDB: any budget permanently blocks drains
-		r.warnSkip(w,
+		r.warnSkip(logger, w, "WorkloadSkipped",
 			"No PDB created for %s: a single pod group with disruptionMode all restarts as a unit, so any PDB would permanently block node drains",
 			w.GetName())
 		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
@@ -449,7 +452,7 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 }
 
 // applyGangBudget rewrites config.MinAvailable for the gang shape; false means no valid PDB exists.
-func (r *WorkloadAPIReconciler) applyGangBudget(config *AvailabilityConfig, in gangReconcileInput, w *workloadAPIObject) bool {
+func (r *WorkloadAPIReconciler) applyGangBudget(logger *logging.UnifiedLogger, config *AvailabilityConfig, in gangReconcileInput, w *workloadAPIObject) bool {
 	if in.gang.DisruptAll {
 		// the whole group restarts together, so quantize the budget to whole groups
 		config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, in.groupCount, in.maxGroupSize)
@@ -461,7 +464,7 @@ func (r *WorkloadAPIReconciler) applyGangBudget(config *AvailabilityConfig, in g
 	// a single independently-disrupted gang keeps pod semantics floored at minCount
 	floored, ok := floorAtMinCount(config.MinAvailable, in.gang.MinCount, w.pods)
 	if !ok {
-		r.warnSkip(w,
+		r.warnSkip(logger, w, "WorkloadSkipped",
 			"No PDB created for %s: gang minCount %d leaves no pod evictable, so any PDB would permanently block node drains",
 			w.GetName(), in.gang.MinCount)
 		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "min_count_blocks_drains")
@@ -516,9 +519,12 @@ func (r *WorkloadAPIReconciler) collectTemplatePods(ctx context.Context, namespa
 	return groups, all, nil
 }
 
-func (r *WorkloadAPIReconciler) warnSkip(w *workloadAPIObject, format string, args ...interface{}) {
+// warnSkip logs and emits one skip warning; reason must be unique per cause,
+// because the events.k8s.io correlation key ignores the message (#99).
+func (r *WorkloadAPIReconciler) warnSkip(logger *logging.UnifiedLogger, w *workloadAPIObject, reason, format string, args ...interface{}) {
+	logger.Info(fmt.Sprintf(format, args...), map[string]any{"reason": reason})
 	if r.Events != nil {
-		r.Events.Warnf(w.Unstructured, "WorkloadSkipped", format, args...)
+		r.Events.Warnf(w.Unstructured, reason, format, args...)
 	}
 }
 

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -72,13 +72,13 @@ func newTestPodGroup(name, namespace, workloadName, templateName string) *unstru
 }
 
 // newTestGroupPod builds a pod that references its PodGroup via spec.schedulingGroup.
-func newTestGroupPod(name, namespace, podGroupName string, labels map[string]string) *corev1.Pod {
+func newTestGroupPod(name, podGroupName string, labels map[string]string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 			Labels:    labels,
-			UID:       types.UID(namespace + "/" + name),
+			UID:       types.UID("default/" + name),
 		},
 		Spec: corev1.PodSpec{
 			SchedulingGroup: &corev1.PodSchedulingGroup{PodGroupName: &podGroupName},
@@ -118,7 +118,7 @@ func gangFixture(workloadName string, groups, size int, podLabels map[string]str
 		pgName := fmt.Sprintf("%s-workers-%d", workloadName, g)
 		objs = append(objs, newTestPodGroup(pgName, "default", workloadName, "workers"))
 		for p := 0; p < size; p++ {
-			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), "default", pgName, podLabels))
+			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), pgName, podLabels))
 		}
 	}
 	return objs
@@ -199,7 +199,7 @@ func TestDeriveGroupSelector(t *testing.T) {
 	pods := func(labels ...map[string]string) []corev1.Pod {
 		out := make([]corev1.Pod, len(labels))
 		for i, l := range labels {
-			out[i] = *newTestGroupPod(fmt.Sprintf("p%d", i), "default", "pg", l)
+			out[i] = *newTestGroupPod(fmt.Sprintf("p%d", i), "pg", l)
 		}
 		return out
 	}
@@ -224,7 +224,7 @@ func TestDeriveGroupSelector(t *testing.T) {
 
 	t.Run("over-matching candidate yields nil", func(t *testing.T) {
 		group := pods(map[string]string{"app": "trainer"}, map[string]string{"app": "trainer"})
-		stranger := *newTestGroupPod("stranger", "default", "other", map[string]string{"app": "trainer"})
+		stranger := *newTestGroupPod("stranger", "other", map[string]string{"app": "trainer"})
 		assert.Nil(t, deriveGroupSelector(group, append(group, stranger)))
 	})
 }
@@ -404,11 +404,11 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 
 // drainFakeEvents empties the fake recorder channel into a slice.
 func drainFakeEvents(r *WorkloadAPIReconciler) []string {
-	fake := r.Recorder.(*k8sevents.FakeRecorder)
+	rec := r.Recorder.(*k8sevents.FakeRecorder)
 	var out []string
 	for {
 		select {
-		case e := <-fake.Events:
+		case e := <-rec.Events:
 			out = append(out, e)
 		default:
 			return out
@@ -428,7 +428,7 @@ func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
 
 	// pods appear later: same object, a second skip cause on the same reconcile key
 	for p := 0; p < 2; p++ {
-		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "default", "late-pods-workers-0",
+		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "late-pods-workers-0",
 			map[string]string{"app": "late-pods"})
 		require.NoError(t, r.Create(context.Background(), pod))
 	}
@@ -436,9 +436,9 @@ func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
 	require.NoError(t, err)
 
 	// distinct reasons keep both messages visible: the events.k8s.io key ignores the note (#99)
-	events := strings.Join(drainFakeEvents(r), "\n")
-	assert.Contains(t, events, "WorkloadPDBDeferred")
-	assert.Contains(t, events, "restarts as a unit")
+	emitted := strings.Join(drainFakeEvents(r), "\n")
+	assert.Contains(t, emitted, "WorkloadPDBDeferred")
+	assert.Contains(t, emitted, "restarts as a unit")
 }
 
 func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -399,6 +400,45 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 
 	err := r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb)
 	assert.Error(t, err, "PDB should be cleaned up when no pods remain")
+}
+
+// drainFakeEvents empties the fake recorder channel into a slice.
+func drainFakeEvents(r *WorkloadAPIReconciler) []string {
+	fake := r.Recorder.(*k8sevents.FakeRecorder)
+	var out []string
+	for {
+		select {
+		case e := <-fake.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
+	workload := newTestWorkload("late-pods", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	pg := newTestPodGroup("late-pods-workers-0", "default", "late-pods", "workers")
+	r := newWorkloadAPITestReconciler(workload, pg)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "late-pods", Namespace: "default"}}
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// pods appear later: same object, a second skip cause on the same reconcile key
+	for p := 0; p < 2; p++ {
+		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "default", "late-pods-workers-0",
+			map[string]string{"app": "late-pods"})
+		require.NoError(t, r.Create(context.Background(), pod))
+	}
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// distinct reasons keep both messages visible: the events.k8s.io key ignores the note (#99)
+	events := strings.Join(drainFakeEvents(r), "\n")
+	assert.Contains(t, events, "WorkloadPDBDeferred")
+	assert.Contains(t, events, "restarts as a unit")
 }
 
 func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #99, closes #98. Found while automating the #95 e2e: the single-group no-PDB warning never surfaced in-cluster.

## Root cause (verified in client-go v0.36.2 source)

`tools/events/event_broadcaster.go:58`: the events.k8s.io correlation key is `{eventType, action, reason, reportingController, reportingInstance, regarding, related}`, the note is not part of it. All Workload skip paths shared `reason = action = WorkloadSkipped`, so once the transient "No pods yet" warning existed, every later skip warning for the same Workload was recorded as a series bump of it and its message was discarded. Observed live: a 10-hour-old single-group Workload carried only the "No pods yet" event with `series=3`, while a freshly started manager (new `reportingInstance`, new key) emitted the single-group message immediately.

## Changes

- One reason per cause: `WorkloadPDBDeferred` (no pods yet), `WorkloadSelectorUnresolvable`, `WorkloadUnsupported` (multi/composite templates), `WorkloadSkipped` (no valid PDB possible: single all-mode group, minCount leaves nothing evictable).
- `warnSkip` now also logs the message (#98), so skip decisions leave a trace in the operator logs; the silent 2.7ms reconciles that cost the debugging time are gone.
- Regression test: two consecutive skip causes on the same Workload (no pods, then single group) must both surface in the recorder.

## Verification

`make test` green; the new `TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause` fails on main. The #95 e2e PR is stacked on this and re-verifies the single-group event end-to-end on kind 1.37.