### PR TITLE
test(e2e): run the suite on kind 1.37 and cover Workload API gang PDBs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install kind
         env:
-          KIND_VERSION: v0.32.0
+          KIND_VERSION: v0.33.0
         run: |
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Workload skip warnings after the first are no longer swallowed. The events.k8s.io correlation key ignores the event message, so every skip cause sharing the `WorkloadSkipped` reason collapsed into the first warning's series and later messages (e.g. the single-group no-PDB explanation) were discarded. Each cause now has its own reason: `WorkloadPDBDeferred` (no pods yet), `WorkloadSelectorUnresolvable`, `WorkloadUnsupported` (multi/composite templates), `WorkloadSkipped` (no valid PDB possible), and every skip also writes a log line (#99, #98)
+
 ### Added
 - Gang-aware PDBs from the upstream Workload API (`scheduling.k8s.io/v1beta1`, KEP-4671, beta in Kubernetes 1.37 behind the `GenericWorkload` gate). `disruptionMode: all` templates get budgets quantized to whole pod groups (reusing the LWS math); `single` gangs keep pod semantics floored at the gang `minCount`; shapes whose budget would permanently block drains (single all-mode group, `minCount` covering every pod) get no PDB plus a Warning event. The PDB selector is derived from labels common to the group's pods and validated for exactness, since pods reference their PodGroup through `spec.schedulingGroup.podGroupName` rather than a label. Support activates only when the API is served (#95)
 

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
 		*) \
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
+			$(KIND) create cluster --name $(KIND_CLUSTER) --config test/e2e/kind-config.yaml ;; \
 	esac
 
 .PHONY: test-e2e

--- a/internal/controller/workloadapi_controller.go
+++ b/internal/controller/workloadapi_controller.go
@@ -295,7 +295,7 @@ func (r *WorkloadAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	if !r.applyGangBudget(config, in, w) {
+	if !r.applyGangBudget(logger, config, in, w) {
 		return ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 
@@ -388,7 +388,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 	if len(gangs) > 1 || composite > 0 {
-		r.warnSkip(w, "Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
+		r.warnSkip(logger, w, "WorkloadUnsupported",
+			"Workload %s has multiple or composite gang templates, not yet supported", w.GetName())
 		return in, true, ctrl.Result{}, r.cleanupQuietly(ctx, w, logger)
 	}
 	in.gang = gangs[0]
@@ -400,7 +401,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 	}
 
 	if len(groupPods) == 0 {
-		r.warnSkip(w, "No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
+		r.warnSkip(logger, w, "WorkloadPDBDeferred",
+			"No pods for Workload %s yet; PDB deferred until its pod groups have pods", w.GetName())
 		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
 			return in, true, ctrl.Result{}, err
 		}
@@ -421,7 +423,8 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 	}
 	selectorLabels := deriveGroupSelector(groupPods, allPods.Items)
 	if selectorLabels == nil {
-		r.warnSkip(w, "No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
+		r.warnSkip(logger, w, "WorkloadSelectorUnresolvable",
+			"No exact label selector derivable for Workload %s pods; cannot create a safe PDB", w.GetName())
 		if err := r.cleanupQuietly(ctx, w, logger); err != nil {
 			return in, true, ctrl.Result{}, err
 		}
@@ -439,7 +442,7 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 
 	if in.gang.DisruptAll && in.groupCount < 2 {
 		// a single all-mode group has no valid PDB: any budget permanently blocks drains
-		r.warnSkip(w,
+		r.warnSkip(logger, w, "WorkloadSkipped",
 			"No PDB created for %s: a single pod group with disruptionMode all restarts as a unit, so any PDB would permanently block node drains",
 			w.GetName())
 		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "single_group")
@@ -449,7 +452,7 @@ func (r *WorkloadAPIReconciler) prepareGangInput(ctx context.Context, w *workloa
 }
 
 // applyGangBudget rewrites config.MinAvailable for the gang shape; false means no valid PDB exists.
-func (r *WorkloadAPIReconciler) applyGangBudget(config *AvailabilityConfig, in gangReconcileInput, w *workloadAPIObject) bool {
+func (r *WorkloadAPIReconciler) applyGangBudget(logger *logging.UnifiedLogger, config *AvailabilityConfig, in gangReconcileInput, w *workloadAPIObject) bool {
 	if in.gang.DisruptAll {
 		// the whole group restarts together, so quantize the budget to whole groups
 		config.MinAvailable = QuantizeMinAvailableForGroups(config.MinAvailable, in.groupCount, in.maxGroupSize)
@@ -461,7 +464,7 @@ func (r *WorkloadAPIReconciler) applyGangBudget(config *AvailabilityConfig, in g
 	// a single independently-disrupted gang keeps pod semantics floored at minCount
 	floored, ok := floorAtMinCount(config.MinAvailable, in.gang.MinCount, w.pods)
 	if !ok {
-		r.warnSkip(w,
+		r.warnSkip(logger, w, "WorkloadSkipped",
 			"No PDB created for %s: gang minCount %d leaves no pod evictable, so any PDB would permanently block node drains",
 			w.GetName(), in.gang.MinCount)
 		metrics.UpdateComplianceStatus(w.GetNamespace(), w.GetName(), false, "min_count_blocks_drains")
@@ -516,9 +519,12 @@ func (r *WorkloadAPIReconciler) collectTemplatePods(ctx context.Context, namespa
 	return groups, all, nil
 }
 
-func (r *WorkloadAPIReconciler) warnSkip(w *workloadAPIObject, format string, args ...interface{}) {
+// warnSkip logs and emits one skip warning; reason must be unique per cause,
+// because the events.k8s.io correlation key ignores the message (#99).
+func (r *WorkloadAPIReconciler) warnSkip(logger *logging.UnifiedLogger, w *workloadAPIObject, reason, format string, args ...interface{}) {
+	logger.Info(fmt.Sprintf(format, args...), map[string]any{"reason": reason})
 	if r.Events != nil {
-		r.Events.Warnf(w.Unstructured, "WorkloadSkipped", format, args...)
+		r.Events.Warnf(w.Unstructured, reason, format, args...)
 	}
 }
 

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -72,13 +72,13 @@ func newTestPodGroup(name, namespace, workloadName, templateName string) *unstru
 }
 
 // newTestGroupPod builds a pod that references its PodGroup via spec.schedulingGroup.
-func newTestGroupPod(name, namespace, podGroupName string, labels map[string]string) *corev1.Pod {
+func newTestGroupPod(name, podGroupName string, labels map[string]string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 			Labels:    labels,
-			UID:       types.UID(namespace + "/" + name),
+			UID:       types.UID("default/" + name),
 		},
 		Spec: corev1.PodSpec{
 			SchedulingGroup: &corev1.PodSchedulingGroup{PodGroupName: &podGroupName},
@@ -118,7 +118,7 @@ func gangFixture(workloadName string, groups, size int, podLabels map[string]str
 		pgName := fmt.Sprintf("%s-workers-%d", workloadName, g)
 		objs = append(objs, newTestPodGroup(pgName, "default", workloadName, "workers"))
 		for p := 0; p < size; p++ {
-			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), "default", pgName, podLabels))
+			objs = append(objs, newTestGroupPod(fmt.Sprintf("%s-%d", pgName, p), pgName, podLabels))
 		}
 	}
 	return objs
@@ -199,7 +199,7 @@ func TestDeriveGroupSelector(t *testing.T) {
 	pods := func(labels ...map[string]string) []corev1.Pod {
 		out := make([]corev1.Pod, len(labels))
 		for i, l := range labels {
-			out[i] = *newTestGroupPod(fmt.Sprintf("p%d", i), "default", "pg", l)
+			out[i] = *newTestGroupPod(fmt.Sprintf("p%d", i), "pg", l)
 		}
 		return out
 	}
@@ -224,7 +224,7 @@ func TestDeriveGroupSelector(t *testing.T) {
 
 	t.Run("over-matching candidate yields nil", func(t *testing.T) {
 		group := pods(map[string]string{"app": "trainer"}, map[string]string{"app": "trainer"})
-		stranger := *newTestGroupPod("stranger", "default", "other", map[string]string{"app": "trainer"})
+		stranger := *newTestGroupPod("stranger", "other", map[string]string{"app": "trainer"})
 		assert.Nil(t, deriveGroupSelector(group, append(group, stranger)))
 	})
 }
@@ -404,11 +404,11 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 
 // drainFakeEvents empties the fake recorder channel into a slice.
 func drainFakeEvents(r *WorkloadAPIReconciler) []string {
-	fake := r.Recorder.(*k8sevents.FakeRecorder)
+	rec := r.Recorder.(*k8sevents.FakeRecorder)
 	var out []string
 	for {
 		select {
-		case e := <-fake.Events:
+		case e := <-rec.Events:
 			out = append(out, e)
 		default:
 			return out
@@ -428,7 +428,7 @@ func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
 
 	// pods appear later: same object, a second skip cause on the same reconcile key
 	for p := 0; p < 2; p++ {
-		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "default", "late-pods-workers-0",
+		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "late-pods-workers-0",
 			map[string]string{"app": "late-pods"})
 		require.NoError(t, r.Create(context.Background(), pod))
 	}
@@ -436,9 +436,9 @@ func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
 	require.NoError(t, err)
 
 	// distinct reasons keep both messages visible: the events.k8s.io key ignores the note (#99)
-	events := strings.Join(drainFakeEvents(r), "\n")
-	assert.Contains(t, events, "WorkloadPDBDeferred")
-	assert.Contains(t, events, "restarts as a unit")
+	emitted := strings.Join(drainFakeEvents(r), "\n")
+	assert.Contains(t, emitted, "WorkloadPDBDeferred")
+	assert.Contains(t, emitted, "restarts as a unit")
 }
 
 func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {

--- a/internal/controller/workloadapi_controller_test.go
+++ b/internal/controller/workloadapi_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -399,6 +400,45 @@ func TestWorkloadAPIReconciler_ScaleToZeroGroups_CleansUpPDB(t *testing.T) {
 
 	err := r.Get(context.Background(), types.NamespacedName{Name: "shrink-pdb", Namespace: "default"}, pdb)
 	assert.Error(t, err, "PDB should be cleaned up when no pods remain")
+}
+
+// drainFakeEvents empties the fake recorder channel into a slice.
+func drainFakeEvents(r *WorkloadAPIReconciler) []string {
+	fake := r.Recorder.(*k8sevents.FakeRecorder)
+	var out []string
+	for {
+		select {
+		case e := <-fake.Events:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+func TestWorkloadAPIReconciler_SkipReasons_DistinctPerCause(t *testing.T) {
+	workload := newTestWorkload("late-pods", 2, true,
+		map[string]string{AnnotationAvailabilityClass: "standard"}, nil)
+	pg := newTestPodGroup("late-pods-workers-0", "default", "late-pods", "workers")
+	r := newWorkloadAPITestReconciler(workload, pg)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "late-pods", Namespace: "default"}}
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// pods appear later: same object, a second skip cause on the same reconcile key
+	for p := 0; p < 2; p++ {
+		pod := newTestGroupPod(fmt.Sprintf("late-pods-workers-0-%d", p), "default", "late-pods-workers-0",
+			map[string]string{"app": "late-pods"})
+		require.NoError(t, r.Create(context.Background(), pod))
+	}
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// distinct reasons keep both messages visible: the events.k8s.io key ignores the note (#99)
+	events := strings.Join(drainFakeEvents(r), "\n")
+	assert.Contains(t, events, "WorkloadPDBDeferred")
+	assert.Contains(t, events, "restarts as a unit")
 }
 
 func TestWorkloadAPIReconciler_Deletion_RemovesFinalizerAndPDB(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -104,6 +104,11 @@ var _ = Describe("Manager", Ordered, func() {
 			"--ignore-not-found", "--timeout=60s")
 		_, _ = utils.Run(cmd)
 
+		By("deleting Workloads while the operator can still process their finalizers")
+		cmd = exec.Command("kubectl", "delete", "workloads", "--all", "-n", "default",
+			"--ignore-not-found", "--timeout=60s")
+		_, _ = utils.Run(cmd)
+
 		By("undeploying the controller-manager")
 		cmd = exec.Command("make", "undeploy")
 		_, _ = utils.Run(cmd)
@@ -760,18 +765,6 @@ spec:
 			_, _ = utils.Run(cmd)
 		}
 
-		// evictPod issues a policy/v1 Eviction through the API server.
-		evictPod := func(podName string) (string, error) {
-			eviction := fmt.Sprintf(
-				`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":%q,"namespace":%q}}`,
-				podName, testNamespace)
-			cmd := exec.Command("kubectl", "create", "--raw",
-				fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/eviction", testNamespace, podName),
-				"-f", "-")
-			cmd.Stdin = strings.NewReader(eviction)
-			return utils.Run(cmd)
-		}
-
 		// readyStatuses returns the Ready condition status of every pod of the LWS.
 		readyStatuses := func(g Gomega, name string) []string {
 			cmd := exec.Command("kubectl", "get", "pods",
@@ -919,7 +912,7 @@ spec:
 			groupZeroPods := strings.Fields(output)
 			Expect(groupZeroPods).To(HaveLen(2), "group 0 should have leader + 1 worker")
 			for _, pod := range groupZeroPods {
-				_, err := evictPod(pod)
+				_, err := evictPod(testNamespace, pod)
 				Expect(err).NotTo(HaveOccurred(), "eviction of %s should be admitted", pod)
 			}
 
@@ -936,7 +929,7 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			groupOnePod := strings.TrimSpace(output)
 			Expect(groupOnePod).NotTo(BeEmpty())
-			evictOutput, err := evictPod(groupOnePod)
+			evictOutput, err := evictPod(testNamespace, groupOnePod)
 			Expect(err).To(HaveOccurred(), "eviction should be rejected while the budget is exhausted")
 			Expect(evictOutput).To(ContainSubstring("disruption budget"))
 
@@ -947,7 +940,7 @@ spec:
 			}).Should(Succeed())
 
 			By("evicting the group-1 pod now that the budget has recovered")
-			_, err = evictPod(groupOnePod)
+			_, err = evictPod(testNamespace, groupOnePod)
 			Expect(err).NotTo(HaveOccurred(), "eviction should succeed after recovery")
 		})
 
@@ -1008,7 +1001,229 @@ spec:
 			}, 15*time.Second, 3*time.Second).Should(Succeed())
 		})
 	})
+
+	Context("Workload API gang PDB management", func() {
+		const testNamespace = "default"
+
+		// skipUnlessWorkloadAPIServed skips the spec on clusters without scheduling.k8s.io/v1beta1.
+		skipUnlessWorkloadAPIServed := func() {
+			cmd := exec.Command("kubectl", "api-resources", "--api-group=scheduling.k8s.io", "-o", "name")
+			output, err := utils.Run(cmd)
+			if err != nil || !strings.Contains(output, "workloads.scheduling.k8s.io") {
+				Skip("Workload API (scheduling.k8s.io/v1beta1) not served on this cluster")
+			}
+		}
+
+		// cleanupWorkload removes a fixture's pods, pod groups, Workload, PDB, and policy; idempotent.
+		// The Workload delete blocks so the operator can process the PDB-cleanup finalizer.
+		cleanupWorkload := func(name string) {
+			cmd := exec.Command("kubectl", "delete", "pods", "-l", "app="+name, "-n", testNamespace,
+				"--ignore-not-found", "--wait=false", "--grace-period=0")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "workload", name, "-n", testNamespace,
+				"--ignore-not-found", "--timeout=60s")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "podgroups", "-l", "app="+name, "-n", testNamespace,
+				"--ignore-not-found", "--wait=false")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pdb", name+"-pdb", "-n", testNamespace,
+				"--ignore-not-found", "--wait=false")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "pdbpolicy", name+"-policy", "-n", testNamespace,
+				"--ignore-not-found", "--wait=false")
+			_, _ = utils.Run(cmd)
+		}
+
+		// gangWorkloadYAML renders a gang Workload plus its pod groups and pause pods.
+		gangWorkloadYAML := func(name string, groups, size int, annotationClass string) string {
+			var b strings.Builder
+			annotations := ""
+			if annotationClass != "" {
+				annotations = fmt.Sprintf("\n  annotations:\n    pdboperator.io/availability-class: %s", annotationClass)
+			}
+			fmt.Fprintf(&b, `apiVersion: scheduling.k8s.io/v1beta1
+kind: Workload
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: %s%s
+spec:
+  podGroupTemplates:
+  - name: workers
+    schedulingPolicy:
+      gang:
+        minCount: %d
+    disruptionMode:
+      all: {}
+`, name, testNamespace, name, annotations, size)
+			for g := 0; g < groups; g++ {
+				pgName := fmt.Sprintf("%s-workers-%d", name, g)
+				fmt.Fprintf(&b, `---
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: %s
+spec:
+  workloadRef:
+    workloadName: %s
+    templateName: workers
+  schedulingPolicy:
+    gang:
+      minCount: %d
+  disruptionMode:
+    all: {}
+`, pgName, testNamespace, name, name, size)
+				for p := 0; p < size; p++ {
+					fmt.Fprintf(&b, `---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s-%d
+  namespace: %s
+  labels:
+    app: %s
+spec:
+  schedulingGroup:
+    podGroupName: %s
+  containers:
+  - name: app
+    image: registry.k8s.io/pause:3.10
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+`, pgName, p, testNamespace, name, pgName)
+				}
+			}
+			return b.String()
+		}
+
+		disruptionsAllowed := func(g Gomega, name string) string {
+			cmd := exec.Command("kubectl", "get", "pdb", name+"-pdb", "-n", testNamespace,
+				"-o", "jsonpath={.status.disruptionsAllowed}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			return output
+		}
+
+		It("should quantize the PDB to whole pod groups and gate evictions at group granularity", func() {
+			skipUnlessWorkloadAPIServed()
+			const wName = "e2e-wapi-gang"
+			cleanupWorkload(wName)
+			DeferCleanup(func() { cleanupWorkload(wName) })
+
+			By("creating a mission-critical PDBPolicy selecting the Workload")
+			policyYAML := fmt.Sprintf(`
+apiVersion: availability.pdboperator.io/v1alpha1
+kind: PDBPolicy
+metadata:
+  name: %s-policy
+  namespace: %s
+spec:
+  availabilityClass: mission-critical
+  enforcement: strict
+  workloadSelector:
+    matchLabels:
+      app: %s
+  priority: 100
+`, wName, testNamespace, wName)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(strings.ReplaceAll(policyYAML, "\t", ""))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create PDBPolicy")
+
+			By("creating a gang Workload with 4 pod groups of 2 pause pods")
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(gangWorkloadYAML(wName, 4, 2, ""))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create Workload fixture")
+
+			By("waiting for the group-quantized PDB derived from the pod labels")
+			// mission-critical (90%) over 4 groups: ceil(0.9*4)=4, clamped to 3 groups x 2 pods = 6
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pdb", wName+"-pdb", "-n", testNamespace,
+					"-o", "jsonpath={.spec.minAvailable} {.spec.selector.matchLabels.app} "+
+						"{.metadata.ownerReferences[0].kind}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "PDB should exist")
+				g.Expect(output).To(Equal("6 "+wName+" Workload"),
+					"minAvailable should be quantized to 3 groups x 2 pods, selector derived from pod labels")
+			}).Should(Succeed())
+
+			By("waiting for the PDB to allow exactly one group of disruptions")
+			Eventually(func(g Gomega) {
+				g.Expect(disruptionsAllowed(g, wName)).To(Equal("2"))
+			}).Should(Succeed())
+
+			By("evicting both pods of group 0 in one pass")
+			for _, pod := range []string{wName + "-workers-0-0", wName + "-workers-0-1"} {
+				_, err := evictPod(testNamespace, pod)
+				Expect(err).NotTo(HaveOccurred(), "eviction of %s should be admitted", pod)
+			}
+
+			By("waiting for the budget to be exhausted")
+			Eventually(func(g Gomega) {
+				g.Expect(disruptionsAllowed(g, wName)).To(Equal("0"))
+			}, 30*time.Second).Should(Succeed())
+
+			By("asserting an eviction from another group is rejected")
+			evictOutput, err := evictPod(testNamespace, wName+"-workers-1-0")
+			Expect(err).To(HaveOccurred(), "eviction should be rejected while the budget is exhausted")
+			Expect(evictOutput).To(ContainSubstring("disruption budget"))
+		})
+
+		It("should skip PDB creation for a single-group Workload and emit a warning", func() {
+			skipUnlessWorkloadAPIServed()
+			const wName = "e2e-wapi-single"
+			cleanupWorkload(wName)
+			DeferCleanup(func() { cleanupWorkload(wName) })
+
+			By("creating a single-group gang Workload")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(gangWorkloadYAML(wName, 1, 2, "mission-critical"))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create single-group Workload fixture")
+
+			By("waiting for the single-group WorkloadSkipped warning event")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "events", "-n", testNamespace)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				found := false
+				for _, line := range utils.GetNonEmptyLines(output) {
+					if strings.Contains(line, "WorkloadSkipped") && strings.Contains(line, wName) &&
+						strings.Contains(line, "restarts as a unit") {
+						found = true
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected a single-group WorkloadSkipped event for %s", wName)
+			}).Should(Succeed())
+
+			By("confirming no PDB is created for the single group")
+			Consistently(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pdb", wName+"-pdb", "-n", testNamespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "PDB should not exist for a single-group Workload")
+			}, 15*time.Second, 3*time.Second).Should(Succeed())
+		})
+	})
 })
+
+// evictPod issues a policy/v1 Eviction through the API server.
+func evictPod(namespace, podName string) (string, error) {
+	eviction := fmt.Sprintf(
+		`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":%q,"namespace":%q}}`,
+		podName, namespace)
+	cmd := exec.Command("kubectl", "create", "--raw",
+		fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/eviction", namespace, podName),
+		"-f", "-")
+	cmd.Stdin = strings.NewReader(eviction)
+	return utils.Run(cmd)
+}
 
 // verifyScaleDownCleansUpPDB creates a 3-replica workload of the given kind, waits for its
 // PDB, scales it to 1, and asserts the orphaned PDB is cleaned up. kind is the API Kind

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -912,7 +912,7 @@ spec:
 			groupZeroPods := strings.Fields(output)
 			Expect(groupZeroPods).To(HaveLen(2), "group 0 should have leader + 1 worker")
 			for _, pod := range groupZeroPods {
-				_, err := evictPod(testNamespace, pod)
+				_, err := evictPod(pod)
 				Expect(err).NotTo(HaveOccurred(), "eviction of %s should be admitted", pod)
 			}
 
@@ -929,7 +929,7 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			groupOnePod := strings.TrimSpace(output)
 			Expect(groupOnePod).NotTo(BeEmpty())
-			evictOutput, err := evictPod(testNamespace, groupOnePod)
+			evictOutput, err := evictPod(groupOnePod)
 			Expect(err).To(HaveOccurred(), "eviction should be rejected while the budget is exhausted")
 			Expect(evictOutput).To(ContainSubstring("disruption budget"))
 
@@ -940,7 +940,7 @@ spec:
 			}).Should(Succeed())
 
 			By("evicting the group-1 pod now that the budget has recovered")
-			_, err = evictPod(testNamespace, groupOnePod)
+			_, err = evictPod(groupOnePod)
 			Expect(err).NotTo(HaveOccurred(), "eviction should succeed after recovery")
 		})
 
@@ -1161,7 +1161,7 @@ spec:
 
 			By("evicting both pods of group 0 in one pass")
 			for _, pod := range []string{wName + "-workers-0-0", wName + "-workers-0-1"} {
-				_, err := evictPod(testNamespace, pod)
+				_, err := evictPod(pod)
 				Expect(err).NotTo(HaveOccurred(), "eviction of %s should be admitted", pod)
 			}
 
@@ -1171,7 +1171,7 @@ spec:
 			}, 30*time.Second).Should(Succeed())
 
 			By("asserting an eviction from another group is rejected")
-			evictOutput, err := evictPod(testNamespace, wName+"-workers-1-0")
+			evictOutput, err := evictPod(wName + "-workers-1-0")
 			Expect(err).To(HaveOccurred(), "eviction should be rejected while the budget is exhausted")
 			Expect(evictOutput).To(ContainSubstring("disruption budget"))
 		})
@@ -1213,13 +1213,13 @@ spec:
 	})
 })
 
-// evictPod issues a policy/v1 Eviction through the API server.
-func evictPod(namespace, podName string) (string, error) {
+// evictPod issues a policy/v1 Eviction for a pod in the default test namespace.
+func evictPod(podName string) (string, error) {
 	eviction := fmt.Sprintf(
-		`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":%q,"namespace":%q}}`,
-		podName, namespace)
+		`{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":%q,"namespace":"default"}}`,
+		podName)
 	cmd := exec.Command("kubectl", "create", "--raw",
-		fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/eviction", namespace, podName),
+		fmt.Sprintf("/api/v1/namespaces/default/pods/%s/eviction", podName),
 		"-f", "-")
 	cmd.Stdin = strings.NewReader(eviction)
 	return utils.Run(cmd)

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -1,0 +1,10 @@
+# e2e cluster: k8s 1.37 with the Workload API (KEP-4671) served
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  GenericWorkload: true
+runtimeConfig:
+  "scheduling.k8s.io/v1beta1": "true"
+nodes:
+- role: control-plane
+  image: kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5


### PR DESCRIPTION
## Summary

Completes the last acceptance item of #95. Stacked on #100 (its commits appear here until it merges; the e2e single-group spec is what surfaced that bug).

## Changes

- `test/e2e/kind-config.yaml`: pins the e2e cluster to `kindest/node:v1.37.0` (by digest) with `featureGates: {GenericWorkload: true}` and `runtimeConfig: {scheduling.k8s.io/v1beta1: true}`; `setup-test-e2e` now passes the config. CI kind bumps v0.32.0 -> v0.33.0, the release which ships that node image.
- New **Workload API gang PDB management** context (skips cleanly when the API is not served, so runs against pre-existing clusters still work):
  - a gang Workload (4 pod groups x 2 pause pods, `disruptionMode: all`) under a strict `mission-critical` policy gets `minAvailable: 6` with the selector derived from pod labels and the Workload as owner; both pods of one group evict in one pass, then an eviction from another group is rejected with the disruption-budget error
  - a single-group Workload gets no PDB plus the single-group `WorkloadSkipped` warning (end-to-end regression coverage for #99)
- `evictPod` hoisted to a shared package-level helper (used by the LWS specs too); suite teardown deletes Workloads before the operator undeploys so their finalizers get processed.

## Verification

Full local run on kind 1.37: **13/13 specs pass** (349s). Before #100 the single-group spec failed exactly as the bug predicts: the warning was swallowed into the "no pods yet" event's series.