### PR TITLE
docs(changelog): add 0.5.0 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-29
+
 ### Fixed
 - Workload skip warnings after the first are no longer swallowed. The events.k8s.io correlation key ignores the event message, so every skip cause sharing the `WorkloadSkipped` reason collapsed into the first warning's series and later messages (e.g. the single-group no-PDB explanation) were discarded. Each cause now has its own reason: `WorkloadPDBDeferred` (no pods yet), `WorkloadSelectorUnresolvable`, `WorkloadUnsupported` (multi/composite templates), `WorkloadSkipped` (no valid PDB possible), and every skip also writes a log line (#99, #98)
 


### PR DESCRIPTION
Release prep for v0.5.0. Moves the `[Unreleased]` entries into a dated `## [0.5.0]` section:

- Gang-aware PDBs from the upstream Workload API, `scheduling.k8s.io/v1beta1` (#95, #97)
- Distinct event reasons per Workload skip cause plus a log line per skip (#99, #98, #100)
- e2e: LWS gang-disruption scenario (#83, #96) and kind 1.37 with the Workload API suite (#101)

Tag `v0.5.0` follows once this merges. Chart release (0.6.0, appVersion v0.5.0) after the image is published.